### PR TITLE
feat(controller): maxDrawers config

### DIFF
--- a/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
@@ -5,6 +5,7 @@ import com.jaquadro.minecraft.storagedrawers.api.inventory.IDrawerInventory;
 import com.jaquadro.minecraft.storagedrawers.api.security.ISecurityProvider;
 import com.jaquadro.minecraft.storagedrawers.api.storage.*;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.*;
+import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockSlave;
 import com.jaquadro.minecraft.storagedrawers.security.SecurityManager;
 import com.jaquadro.minecraft.storagedrawers.util.ItemMetaListRegistry;
@@ -128,6 +129,8 @@ public class TileEntityController extends TileEntity implements IDrawerGroup, IP
 
     private int drawerSize = 0;
     private int range;
+    private int maxDrawers;
+    private int drawersCount;
 
     private long lastClickTime;
     private UUID lastClickUUID;
@@ -138,6 +141,7 @@ public class TileEntityController extends TileEntity implements IDrawerGroup, IP
         invSlotList.add(new SlotRecord(null, 0));
         inventorySlots = new int[] { 0 };
         range = StorageDrawers.config.getControllerRange();
+        maxDrawers = StorageDrawers.config.getControllerMaxDrawers();
     }
 
     public int getDirection () {
@@ -544,6 +548,8 @@ public class TileEntityController extends TileEntity implements IDrawerGroup, IP
         searchDiscovered.clear();
         searchDiscovered.add(root);
 
+        drawersCount = 0;
+
         while (!searchQueue.isEmpty()) {
             BlockCoord coord = searchQueue.remove();
             int depth = Math.max(Math.max(Math.abs(coord.x() - x), Math.abs(coord.y() - y)), Math.abs(coord.z() - z));
@@ -562,7 +568,7 @@ public class TileEntityController extends TileEntity implements IDrawerGroup, IP
 
             if (block instanceof BlockSlave) {
                 ((BlockSlave) block).getTileEntitySafe(worldObj, coord.x(), coord.y(), coord.z());
-            }
+            } else if (block instanceof BlockDrawers && ++drawersCount > maxDrawers) break;
 
             updateRecordInfo(coord, record, worldObj.getTileEntity(coord.x(), coord.y(), coord.z()));
             record.mark = true;

--- a/src/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
+++ b/src/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
@@ -303,6 +303,7 @@ public class ConfigManager
 
         config.get(sectionBlocksController.getQualifiedName(), "enabled", true).setLanguageKey(LANG_PREFIX + "prop.enabled").setRequiresMcRestart(true);
         config.get(sectionBlocksController.getQualifiedName(), "range", 12).setLanguageKey(LANG_PREFIX + "prop.controllerRange");
+        config.get(sectionBlocksController.getQualifiedName(), "maxDrawers", 2048).setLanguageKey(LANG_PREFIX + "prop.controllerMaxDrawers");
 
         config.get(sectionBlocksTrim.getQualifiedName(), "enabled", true).setLanguageKey(LANG_PREFIX + "prop.enabled").setRequiresMcRestart(true);
         config.get(sectionBlocksTrim.getQualifiedName(), "recipeOutput", 4).setLanguageKey(LANG_PREFIX + "prop.recipeOutput").setRequiresMcRestart(true);
@@ -320,6 +321,7 @@ public class ConfigManager
         cache.addonSeparateVanilla = config.get(sectionAddons.getQualifiedName(), "useSeparateCreativeTabs", true).setLanguageKey(LANG_PREFIX + "addons.separateTabs").setRequiresMcRestart(true).getBoolean();
 
         getControllerRange();
+        getControllerMaxDrawers();
 
         if (config.hasChanged())
             config.save();
@@ -360,6 +362,11 @@ public class ConfigManager
     public int getControllerRange () {
         ConfigSection section = blockSectionsMap.get("controller");
         return section.getCategory().get("range").getInt();
+    }
+
+    public int getControllerMaxDrawers () {
+        ConfigSection section = blockSectionsMap.get("controller");
+        return section.getCategory().get("maxDrawers").getInt();
     }
 
     public int getStorageUpgradeMultiplier (int level) {


### PR DESCRIPTION
Fix a server load issue with extreme drawers setup reported in
the #moderators channel by Elisis.

Implements the suggestion from @Prometheus0000:
> Is there a way to limit it to not range, but number of drawers?
> Without too big a code change?

Here is a maxDrawers configuration for the drawers controller.

maxDrawers default value is 2048 and is found in the controller section.

`StorageDrawers.cfg`:
```yaml
    controller {
        B:enabled=true
        I:maxDrawers=2048
        I:range=12
    }
```