### PR TITLE
Fix drawers not marking the chunk they're in for saving, which caused lost/duped items

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DefaultStorageProvider.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DefaultStorageProvider.java
@@ -89,6 +89,7 @@ public class DefaultStorageProvider implements IStorageProvider
 
         StorageDrawers.network.sendToAllAround(message, targetPoint);
 
+        tile.getWorldObj().markTileEntityChunkModified(tile.xCoord, tile.yCoord, tile.zCoord, tile);
         if (isRedstone(slot)) {
             tile.getWorldObj().notifyBlocksOfNeighborChange(tile.xCoord, tile.yCoord, tile.zCoord, tile.getBlockType());
             tile.getWorldObj().notifyBlocksOfNeighborChange(tile.xCoord, tile.yCoord - 1, tile.zCoord, tile.getBlockType());
@@ -101,5 +102,6 @@ public class DefaultStorageProvider implements IStorageProvider
             return;
 
         tile.getWorldObj().markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);
+        tile.getWorldObj().markTileEntityChunkModified(tile.xCoord, tile.yCoord, tile.zCoord, tile);
     }
 }


### PR DESCRIPTION
Drawers did not call the right vanilla functions to mark chunks as dirty when items were moved in/out of them.