### PR TITLE
Allow clearing empty items from locked drawers

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -373,6 +373,18 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
                     } else
                 if (item.getItem() == ModItems.upgradeLock) {
                     boolean locked = tileDrawers.isLocked(LockAttribute.LOCK_POPULATED);
+
+                    if (locked) {
+                        int slot = getDrawerSlot(side, hitX, hitY, hitZ);
+                        IDrawer drawer = tileDrawers.getDrawer(slot);
+                        ItemStack stack = drawer.getStoredItemPrototype();
+                        int count = drawer.getStoredItemCount();
+
+                        if (stack != null && count == 0) {
+                            drawer.setStoredItemRedir(null, 0);
+                            return true;
+                        }
+                    }
                     tileDrawers.setLocked(LockAttribute.LOCK_POPULATED, !locked);
                     tileDrawers.setLocked(LockAttribute.LOCK_EMPTY, !locked);
 


### PR DESCRIPTION
This makes it so that if you right click an empty item stack on a locked drawer with the drawer key, it will clear the item, but not unlock the drawer. The drawer will only unlock if it is clicked on an item stack which is not empty(previous behavior), or an completely clear drawer.

Prior to this, in order to clear an item from a locked drawer, you had to unlock the drawer, put some of the item in, take it out so that it would clear the drawer like normal, and then lock it again. In systems with a lot of automation leveraging locked drawers, this can lead to undesired items being stuck into the drawer when you're trying to just clear it.

Here is a quick video demonstration: https://streamable.com/6jijtq