### PR TITLE
Fix Waila showing default stack limit when downgraded

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -183,7 +183,7 @@ public abstract class TileEntityDrawers extends BaseTileEntity implements IDrawe
     }
 
     public int getDrawerCapacity() {
-        return drawerCapacity;
+        return isDowngraded() ? 1 : drawerCapacity;
     }
 
     public void setDrawerCapacity(int stackCount) {


### PR DESCRIPTION
From what I can tell the downgrade upgrade works perfectly fine. The change in size is however not reflected in the Waila tooltip.

Beforehand it would show this with a downgrade along with a three 5x upgrades and one 3x.
![downgradepre](https://github.com/GTNewHorizons/StorageDrawers/assets/127234178/15fd5c7b-28b7-4656-aa29-567797b3a889)

And now it shows this
![downgradepost](https://github.com/GTNewHorizons/StorageDrawers/assets/127234178/e876be97-e026-4ce2-a3bd-fe8bc3be6395)

Despite showing a stack limit of 576 in the first picture it was only able to hold 18 stacks which is the correct amount in this scenario.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15500