### PR TITLE
Add nullCheck for 'protoStack[0]' to prevent crash when there is a removal of an item from the modpack.

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
@@ -566,7 +566,7 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
 
         @Override
         public int getMaxCapacity(int slot) {
-            if (protoStack[slot] == null || convRate == null || convRate[slot] == 0) return 0;
+            if (protoStack[slot] == null || protoStack[0] == null || convRate == null || convRate[slot] == 0) return 0;
 
             if (TileEntityDrawersComp.this.isUnlimited() || TileEntityDrawersComp.this.isVending()) {
                 if (convRate == null || protoStack[slot] == null || convRate[slot] == 0) return Integer.MAX_VALUE;


### PR DESCRIPTION
If an item that was inside a drawer is removed from the modpack, **the protoStack[0] can be null.**

_At least when another mod is trying to insert something else like enderio._

<details>

<summary>CrashReport</summary>

```
---- Minecraft Crash Report ----
// Surprise! Haha. Well, this is awkward.

Time: 3/11/24, 2:57 AM
Description: Exception in server tick loop

java.lang.NullPointerException: Cannot invoke "net.minecraft.item.ItemStack.func_77973_b()" because "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp.access$100(com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp)[0]" is null
	at com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp$CompCentralInventory.getMaxCapacity(TileEntityDrawersComp.java:576)
	at com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp$CompCentralInventory.getItemCapacityForInventoryStack(TileEntityDrawersComp.java:614)
	at com.jaquadro.minecraft.storagedrawers.storage.CompDrawerData.getItemCapacityForInventoryStack(CompDrawerData.java:79)
	at com.jaquadro.minecraft.storagedrawers.storage.BaseDrawerData$DrawerInventoryStack.getItemCapacity(BaseDrawerData.java:199)
	at com.jaquadro.minecraft.storagedrawers.inventory.InventoryStack.refresh(InventoryStack.java:126)
	at com.jaquadro.minecraft.storagedrawers.inventory.InventoryStack.markDirty(InventoryStack.java:100)
	at com.jaquadro.minecraft.storagedrawers.storage.BaseDrawerData.syncInventory(BaseDrawerData.java:91)
	at com.jaquadro.minecraft.storagedrawers.inventory.StorageInventory.func_70301_a(StorageInventory.java:124)
	at com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers.func_70301_a(TileEntityDrawers.java:882)
	at com.enderio.core.common.util.ItemUtil.doInsertItemInv(ItemUtil.java:375)
	at com.enderio.core.common.util.ItemUtil.doInsertItemInv(ItemUtil.java:362)
	at com.enderio.core.common.util.ItemUtil.doInsertItem(ItemUtil.java:300)
	at crazypants.enderio.conduit.item.NetworkedInventory.insertItem(NetworkedInventory.java:315)
	at crazypants.enderio.conduit.item.NetworkedInventory.insertIntoTargets(NetworkedInventory.java:263)
	at crazypants.enderio.conduit.item.NetworkedInventory.doTransfer(NetworkedInventory.java:212)
	at crazypants.enderio.conduit.item.NetworkedInventory.transferItems(NetworkedInventory.java:180)
	at crazypants.enderio.conduit.item.NetworkedInventory.onTick(NetworkedInventory.java:116)
	at crazypants.enderio.conduit.item.ItemConduitNetwork.doNetworkTick(ItemConduitNetwork.java:224)
	at crazypants.enderio.conduit.ConduitNetworkTickHandler.tickEnd(ConduitNetworkTickHandler.java:63)
	at crazypants.enderio.conduit.ConduitNetworkTickHandler.onServerTick(ConduitNetworkTickHandler.java:47)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_338_ConduitNetworkTickHandler_onServerTick_ServerTickEvent.invoke(.dynamic)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:168)
	at cpw.mods.fml.common.FMLCommonHandler.onPostServerTick(FMLCommonHandler.java:251)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:897)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:695)
	at java.base/java.lang.Thread.run(Thread.java:1583)

```

</details>
