### PR TITLE
Initial thread safety and multi-threaded rendering with Angelica

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 // Add your dependencies here
 
 dependencies {
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha34:api')
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-340-GTNH:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.100:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev') {transitive=false}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha34:api')
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha35:api')
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-340-GTNH:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.100:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev') {transitive=false}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ControllerRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ControllerRenderer.java
@@ -1,5 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
@@ -15,6 +16,7 @@ import com.jaquadro.minecraft.storagedrawers.util.RenderHelperState;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
+@ThreadSafeISBRH(perThread = true)
 public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
     private static final double unit = .0625f;
@@ -37,7 +39,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
         GL11.glRotatef(90, 0, 1, 0);
         GL11.glTranslatef(-.5f, -.5f, -.5f);
 
-        RenderHelper.instance.state
+        RenderHelper.instances.get().state
                 .setUVRotation(RenderHelper.YPOS, RenderHelperState.ROTATION_BY_FACE_FACE[RenderHelper.ZNEG][side]);
 
         renderExterior(block, 0, 0, 0, side, renderer);
@@ -47,7 +49,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
         renderInterior(block, 0, 0, 0, side, renderer);
 
-        RenderHelper.instance.state.clearUVRotation(RenderHelper.YPOS);
+        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
 
         GL11.glTranslatef(.5f, .5f, .5f);
     }
@@ -67,7 +69,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
         int side = tile.getDirection();
 
-        RenderHelper.instance.state
+        RenderHelper.instances.get().state
                 .setUVRotation(RenderHelper.YPOS, RenderHelperState.ROTATION_BY_FACE_FACE[RenderHelper.ZNEG][side]);
 
         boxRenderer.setUnit(unit);
@@ -84,7 +86,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
         renderInterior(block, x, y, z, side, renderer);
 
-        RenderHelper.instance.state.clearUVRotation(RenderHelper.YPOS);
+        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
 
         return true;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ControllerRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ControllerRenderer.java
@@ -1,6 +1,5 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
-import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
@@ -8,6 +7,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockController;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
@@ -21,6 +21,8 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
     private static final double unit = .0625f;
     private ModularBoxRenderer boxRenderer = new ModularBoxRenderer();
+
+    private RenderHelper renderHelper = RenderHelper.instances.get();
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
@@ -39,7 +41,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
         GL11.glRotatef(90, 0, 1, 0);
         GL11.glTranslatef(-.5f, -.5f, -.5f);
 
-        RenderHelper.instances.get().state
+        renderHelper.state
                 .setUVRotation(RenderHelper.YPOS, RenderHelperState.ROTATION_BY_FACE_FACE[RenderHelper.ZNEG][side]);
 
         renderExterior(block, 0, 0, 0, side, renderer);
@@ -49,7 +51,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
         renderInterior(block, 0, 0, 0, side, renderer);
 
-        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
+        renderHelper.state.clearUVRotation(RenderHelper.YPOS);
 
         GL11.glTranslatef(.5f, .5f, .5f);
     }
@@ -69,7 +71,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
         int side = tile.getDirection();
 
-        RenderHelper.instances.get().state
+        renderHelper.state
                 .setUVRotation(RenderHelper.YPOS, RenderHelperState.ROTATION_BY_FACE_FACE[RenderHelper.ZNEG][side]);
 
         boxRenderer.setUnit(unit);
@@ -86,7 +88,7 @@ public class ControllerRenderer implements ISimpleBlockRenderingHandler {
 
         renderInterior(block, x, y, z, side, renderer);
 
-        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
+        renderHelper.state.clearUVRotation(RenderHelper.YPOS);
 
         return true;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersItemRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersItemRenderer.java
@@ -59,8 +59,8 @@ public class DrawersItemRenderer implements IItemRenderer {
 
         if (item.hasTagCompound() && item.getTagCompound().hasKey("tile")) {
             double depth = block.halfDepth ? .5 : 1;
-            RenderHelper.instance.setRenderBounds(1 - depth - .005, 0, 0, 1, 1, 1);
-            RenderHelper.instance.renderFace(side, null, block, block.getTapeIcon(), 1, 1, 1);
+            RenderHelper.instances.get().setRenderBounds(1 - depth - .005, 0, 0, 1, 1, 1);
+            RenderHelper.instances.get().renderFace(side, null, block, block.getTapeIcon(), 1, 1, 1);
         }
 
         if (renderType == ItemRenderType.INVENTORY || renderType == ItemRenderType.ENTITY)
@@ -70,7 +70,7 @@ public class DrawersItemRenderer implements IItemRenderer {
     private void renderBaseBlock(BlockDrawers block, ItemStack item, RenderBlocks renderer) {
         int side = 4;
 
-        RenderHelper.instance.state
+        RenderHelper.instances.get().state
                 .setUVRotation(RenderHelper.YPOS, RenderHelperState.ROTATION_BY_FACE_FACE[RenderHelper.ZPOS][side]);
 
         boxRenderer.setUnit(block.getTrimWidth());
@@ -79,7 +79,7 @@ public class DrawersItemRenderer implements IItemRenderer {
 
         renderExterior(block, 0, 0, 0, side, renderer);
 
-        RenderHelper.instance.state.clearUVRotation(RenderHelper.YPOS);
+        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
 
         boxRenderer.setUnit(0);
         boxRenderer.setInteriorIcon(block.getIcon(side, item.getItemDamage()), ForgeDirection.OPPOSITES[side]);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersItemRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersItemRenderer.java
@@ -24,6 +24,8 @@ public class DrawersItemRenderer implements IItemRenderer {
     // private PanelBoxRenderer panelRenderer = new PanelBoxRenderer();
     // private float[] colorScratch = new float[3];
 
+    private static RenderHelper renderHelper = RenderHelper.instances.get();
+
     @Override
     public boolean handleRenderType(ItemStack item, ItemRenderType type) {
         return true;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersRenderer.java
@@ -1,12 +1,12 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
-import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
@@ -17,11 +17,13 @@ import com.jaquadro.minecraft.storagedrawers.util.RenderHelperState;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
-@ThreadSafeISBRH(perThread = false)
+@ThreadSafeISBRH(perThread = true)
 public class DrawersRenderer implements ISimpleBlockRenderingHandler {
 
     private static final double unit = .0625f;
     private ModularBoxRenderer boxRenderer = new ModularBoxRenderer();
+
+    private RenderHelper renderHelper = RenderHelper.instances.get();
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
@@ -72,7 +74,7 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         int side = tile.getDirection();
         int meta = world.getBlockMetadata(x, y, z);
 
-        RenderHelper.instances.get().state
+        renderHelper.state
                 .setUVRotation(RenderHelper.YPOS, RenderHelperState.ROTATION_BY_FACE_FACE[RenderHelper.ZNEG][side]);
 
         boxRenderer.setUnit(block.getTrimWidth());
@@ -84,7 +86,7 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
 
         renderExterior(block, x, y, z, side, renderer);
 
-        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
+        renderHelper.state.clearUVRotation(RenderHelper.YPOS);
 
         int maxStorageLevel = tile.getMaxStorageLevel();
         if (maxStorageLevel > 1 && StorageDrawers.config.cache.renderStorageUpgrades && !tile.shouldHideUpgrades()) {
@@ -110,11 +112,10 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         double depth = block.halfDepth ? .5 : 1;
         IIcon iconLock = block.getLockIcon(locked, owned);
 
-        RenderHelper.instances.get().setRenderBounds(0.46875, 0.9375, 0, 0.53125, 1, depth + .005);
-        RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
-        RenderHelper.instances.get()
-                .renderPartialFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconLock, 0, 0, 1, 1);
-        RenderHelper.instances.get().state.clearRotateTransform();
+        renderHelper.setRenderBounds(0.46875, 0.9375, 0, 0.53125, 1, depth + .005);
+        renderHelper.state.setRotateTransform(RenderHelper.ZPOS, side);
+        renderHelper.renderPartialFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconLock, 0, 0, 1, 1);
+        renderHelper.state.clearRotateTransform();
     }
 
     private void renderVoid(BlockDrawers block, int x, int y, int z, int side, RenderBlocks renderer, boolean voided) {
@@ -123,11 +124,10 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         double depth = block.halfDepth ? .5 : 1;
         IIcon iconVoid = block.getVoidIcon();
 
-        RenderHelper.instances.get().setRenderBounds(1 - .0625, 0.9375, 0, 1, 1, depth + .005);
-        RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
-        RenderHelper.instances.get()
-                .renderPartialFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconVoid, 0, 0, 1, 1);
-        RenderHelper.instances.get().state.clearRotateTransform();
+        renderHelper.setRenderBounds(1 - .0625, 0.9375, 0, 1, 1, depth + .005);
+        renderHelper.state.setRotateTransform(RenderHelper.ZPOS, side);
+        renderHelper.renderPartialFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconVoid, 0, 0, 1, 1);
+        renderHelper.state.clearRotateTransform();
     }
 
     private void renderTape(BlockDrawers block, int x, int y, int z, int side, RenderBlocks renderer, boolean taped) {
@@ -136,10 +136,10 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         double depth = block.halfDepth ? .5 : 1;
         IIcon iconTape = block.getTapeIcon();
 
-        RenderHelper.instances.get().setRenderBounds(0, 0, 0, 1, 1, depth + .005);
-        RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
-        RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconTape);
-        RenderHelper.instances.get().state.clearRotateTransform();
+        renderHelper.setRenderBounds(0, 0, 0, 1, 1, depth + .005);
+        renderHelper.state.setRotateTransform(RenderHelper.ZPOS, side);
+        renderHelper.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconTape);
+        renderHelper.state.clearRotateTransform();
     }
 
     private static final int[] cut = new int[] {
@@ -209,16 +209,16 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
             float subX = xywh[0] + (xywh[2] - w) / 2;
             float subY = xywh[1] + (xywh[3] - h) / 2;
 
-            RenderHelper.instances.get().setRenderBounds(
+            renderHelper.setRenderBounds(
                     subX * unit,
                     subY * unit,
                     0,
                     (subX + w) * unit,
                     (subY + h) * unit,
                     (depth - depthAdj + .05) * unit);
-            RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
-            RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, icon);
-            RenderHelper.instances.get().state.clearRotateTransform();
+            renderHelper.state.setRotateTransform(RenderHelper.ZPOS, side);
+            renderHelper.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, icon);
+            renderHelper.state.clearRotateTransform();
         }
     }
 
@@ -254,30 +254,30 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
 
             float[] xywh = xywhSet[i];
 
-            RenderHelper.instances.get().setRenderBounds(
+            renderHelper.setRenderBounds(
                     xywh[0] * unit,
                     xywh[1] * unit,
                     0,
                     (xywh[0] + xywh[2]) * unit,
                     (xywh[1] + xywh[3]) * unit,
                     (depth - depthAdj + .05) * unit);
-            RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
-            RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOff);
-            RenderHelper.instances.get().state.clearRotateTransform();
+            renderHelper.state.setRotateTransform(RenderHelper.ZPOS, side);
+            renderHelper.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOff);
+            renderHelper.state.clearRotateTransform();
 
             if (level == 1 && drawer.getMaxCapacity() > 0 && drawer.getRemainingCapacity() == 0) {
-                RenderHelper.instances.get().state.setColorMult(1, 1, .9f, 1);
-                RenderHelper.instances.get().setRenderBounds(
+                renderHelper.state.setColorMult(1, 1, .9f, 1);
+                renderHelper.setRenderBounds(
                         xywh[0] * unit,
                         xywh[1] * unit,
                         0,
                         (xywh[0] + xywh[2]) * unit,
                         (xywh[1] + xywh[3]) * unit,
                         (depth - depthAdj + .06) * unit);
-                RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
-                RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
-                RenderHelper.instances.get().state.clearRotateTransform();
-                RenderHelper.instances.get().state.resetColorMult();
+                renderHelper.state.setRotateTransform(RenderHelper.ZPOS, side);
+                renderHelper.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
+                renderHelper.state.clearRotateTransform();
+                renderHelper.state.resetColorMult();
             } else if (level >= 2) {
                 double indXStart = xywh[0] + block.getIndStart() / unit;
                 double indXEnd = xywh[0] + block.getIndEnd() / unit;
@@ -289,18 +289,18 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
                 double indYCur = indYEnd;
 
                 if (indXCur > indXStart) {
-                    RenderHelper.instances.get().state.setColorMult(1, 1, .9f, 1);
-                    RenderHelper.instances.get().setRenderBounds(
+                    renderHelper.state.setColorMult(1, 1, .9f, 1);
+                    renderHelper.setRenderBounds(
                             indXStart * unit,
                             indYStart * unit,
                             0,
                             indXCur * unit,
                             indYCur * unit,
                             (depth - depthAdj + .06) * unit);
-                    RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
-                    RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
-                    RenderHelper.instances.get().state.clearRotateTransform();
-                    RenderHelper.instances.get().state.resetColorMult();
+                    renderHelper.state.setRotateTransform(RenderHelper.ZPOS, side);
+                    renderHelper.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
+                    renderHelper.state.clearRotateTransform();
+                    renderHelper.state.resetColorMult();
                 }
             }
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersRenderer.java
@@ -1,5 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
@@ -16,6 +17,7 @@ import com.jaquadro.minecraft.storagedrawers.util.RenderHelperState;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
+@ThreadSafeISBRH(perThread = false)
 public class DrawersRenderer implements ISimpleBlockRenderingHandler {
 
     private static final double unit = .0625f;
@@ -70,7 +72,7 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         int side = tile.getDirection();
         int meta = world.getBlockMetadata(x, y, z);
 
-        RenderHelper.instance.state
+        RenderHelper.instances.get().state
                 .setUVRotation(RenderHelper.YPOS, RenderHelperState.ROTATION_BY_FACE_FACE[RenderHelper.ZNEG][side]);
 
         boxRenderer.setUnit(block.getTrimWidth());
@@ -82,7 +84,7 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
 
         renderExterior(block, x, y, z, side, renderer);
 
-        RenderHelper.instance.state.clearUVRotation(RenderHelper.YPOS);
+        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
 
         int maxStorageLevel = tile.getMaxStorageLevel();
         if (maxStorageLevel > 1 && StorageDrawers.config.cache.renderStorageUpgrades && !tile.shouldHideUpgrades()) {
@@ -108,11 +110,11 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         double depth = block.halfDepth ? .5 : 1;
         IIcon iconLock = block.getLockIcon(locked, owned);
 
-        RenderHelper.instance.setRenderBounds(0.46875, 0.9375, 0, 0.53125, 1, depth + .005);
-        RenderHelper.instance.state.setRotateTransform(RenderHelper.ZPOS, side);
-        RenderHelper.instance
+        RenderHelper.instances.get().setRenderBounds(0.46875, 0.9375, 0, 0.53125, 1, depth + .005);
+        RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
+        RenderHelper.instances.get()
                 .renderPartialFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconLock, 0, 0, 1, 1);
-        RenderHelper.instance.state.clearRotateTransform();
+        RenderHelper.instances.get().state.clearRotateTransform();
     }
 
     private void renderVoid(BlockDrawers block, int x, int y, int z, int side, RenderBlocks renderer, boolean voided) {
@@ -121,11 +123,11 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         double depth = block.halfDepth ? .5 : 1;
         IIcon iconVoid = block.getVoidIcon();
 
-        RenderHelper.instance.setRenderBounds(1 - .0625, 0.9375, 0, 1, 1, depth + .005);
-        RenderHelper.instance.state.setRotateTransform(RenderHelper.ZPOS, side);
-        RenderHelper.instance
+        RenderHelper.instances.get().setRenderBounds(1 - .0625, 0.9375, 0, 1, 1, depth + .005);
+        RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
+        RenderHelper.instances.get()
                 .renderPartialFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconVoid, 0, 0, 1, 1);
-        RenderHelper.instance.state.clearRotateTransform();
+        RenderHelper.instances.get().state.clearRotateTransform();
     }
 
     private void renderTape(BlockDrawers block, int x, int y, int z, int side, RenderBlocks renderer, boolean taped) {
@@ -134,10 +136,10 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
         double depth = block.halfDepth ? .5 : 1;
         IIcon iconTape = block.getTapeIcon();
 
-        RenderHelper.instance.setRenderBounds(0, 0, 0, 1, 1, depth + .005);
-        RenderHelper.instance.state.setRotateTransform(RenderHelper.ZPOS, side);
-        RenderHelper.instance.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconTape);
-        RenderHelper.instance.state.clearRotateTransform();
+        RenderHelper.instances.get().setRenderBounds(0, 0, 0, 1, 1, depth + .005);
+        RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
+        RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconTape);
+        RenderHelper.instances.get().state.clearRotateTransform();
     }
 
     private static final int[] cut = new int[] {
@@ -207,16 +209,16 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
             float subX = xywh[0] + (xywh[2] - w) / 2;
             float subY = xywh[1] + (xywh[3] - h) / 2;
 
-            RenderHelper.instance.setRenderBounds(
+            RenderHelper.instances.get().setRenderBounds(
                     subX * unit,
                     subY * unit,
                     0,
                     (subX + w) * unit,
                     (subY + h) * unit,
                     (depth - depthAdj + .05) * unit);
-            RenderHelper.instance.state.setRotateTransform(RenderHelper.ZPOS, side);
-            RenderHelper.instance.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, icon);
-            RenderHelper.instance.state.clearRotateTransform();
+            RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
+            RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, icon);
+            RenderHelper.instances.get().state.clearRotateTransform();
         }
     }
 
@@ -252,30 +254,30 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
 
             float[] xywh = xywhSet[i];
 
-            RenderHelper.instance.setRenderBounds(
+            RenderHelper.instances.get().setRenderBounds(
                     xywh[0] * unit,
                     xywh[1] * unit,
                     0,
                     (xywh[0] + xywh[2]) * unit,
                     (xywh[1] + xywh[3]) * unit,
                     (depth - depthAdj + .05) * unit);
-            RenderHelper.instance.state.setRotateTransform(RenderHelper.ZPOS, side);
-            RenderHelper.instance.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOff);
-            RenderHelper.instance.state.clearRotateTransform();
+            RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
+            RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOff);
+            RenderHelper.instances.get().state.clearRotateTransform();
 
             if (level == 1 && drawer.getMaxCapacity() > 0 && drawer.getRemainingCapacity() == 0) {
-                RenderHelper.instance.state.setColorMult(1, 1, .9f, 1);
-                RenderHelper.instance.setRenderBounds(
+                RenderHelper.instances.get().state.setColorMult(1, 1, .9f, 1);
+                RenderHelper.instances.get().setRenderBounds(
                         xywh[0] * unit,
                         xywh[1] * unit,
                         0,
                         (xywh[0] + xywh[2]) * unit,
                         (xywh[1] + xywh[3]) * unit,
                         (depth - depthAdj + .06) * unit);
-                RenderHelper.instance.state.setRotateTransform(RenderHelper.ZPOS, side);
-                RenderHelper.instance.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
-                RenderHelper.instance.state.clearRotateTransform();
-                RenderHelper.instance.state.resetColorMult();
+                RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
+                RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
+                RenderHelper.instances.get().state.clearRotateTransform();
+                RenderHelper.instances.get().state.resetColorMult();
             } else if (level >= 2) {
                 double indXStart = xywh[0] + block.getIndStart() / unit;
                 double indXEnd = xywh[0] + block.getIndEnd() / unit;
@@ -287,18 +289,18 @@ public class DrawersRenderer implements ISimpleBlockRenderingHandler {
                 double indYCur = indYEnd;
 
                 if (indXCur > indXStart) {
-                    RenderHelper.instance.state.setColorMult(1, 1, .9f, 1);
-                    RenderHelper.instance.setRenderBounds(
+                    RenderHelper.instances.get().state.setColorMult(1, 1, .9f, 1);
+                    RenderHelper.instances.get().setRenderBounds(
                             indXStart * unit,
                             indYStart * unit,
                             0,
                             indXCur * unit,
                             indYCur * unit,
                             (depth - depthAdj + .06) * unit);
-                    RenderHelper.instance.state.setRotateTransform(RenderHelper.ZPOS, side);
-                    RenderHelper.instance.renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
-                    RenderHelper.instance.state.clearRotateTransform();
-                    RenderHelper.instance.state.resetColorMult();
+                    RenderHelper.instances.get().state.setRotateTransform(RenderHelper.ZPOS, side);
+                    RenderHelper.instances.get().renderFace(RenderHelper.ZPOS, renderer.blockAccess, block, x, y, z, iconOn);
+                    RenderHelper.instances.get().state.clearRotateTransform();
+                    RenderHelper.instances.get().state.resetColorMult();
                 }
             }
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/FramingTableRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/FramingTableRenderer.java
@@ -1,12 +1,12 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
-import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
 import org.lwjgl.opengl.GL11;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockFramingTable;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.common.CommonFramingRenderer;
@@ -15,10 +15,12 @@ import com.jaquadro.minecraft.storagedrawers.util.RenderHelper;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
-@ThreadSafeISBRH(perThread = false)
+@ThreadSafeISBRH(perThread = true)
 public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
 
     private CommonFramingRenderer framingRenderer = new CommonFramingRenderer();
+
+    private RenderHelper renderHelper = RenderHelper.instances.get();
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
@@ -37,12 +39,12 @@ public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
         GL11.glTranslatef(.15f, -.5f, -.5f);
         GL11.glScalef(.65f, .65f, .65f);
 
-        RenderHelper.instances.get().state.setUVRotation(RenderHelper.YPOS, RenderHelper.instances.get().state.rotateTransform);
+        renderHelper.state.setUVRotation(RenderHelper.YPOS, renderHelper.state.rotateTransform);
 
         framingRenderer.renderRight(null, 0, 0, 0, framingTable);
         framingRenderer.renderLeft(null, -1, 0, 0, framingTable);
 
-        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
+        renderHelper.state.clearUVRotation(RenderHelper.YPOS);
 
         if (!blendEnabled) GL11.glDisable(GL11.GL_BLEND);
         if (!depthMask) GL11.glDepthMask(false);
@@ -62,8 +64,8 @@ public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
 
         if (side == 2 || side == 3) right = !right;
 
-        RenderHelper.instances.get().state.setRotateTransform(side, RenderHelper.ZNEG);
-        RenderHelper.instances.get().state.setUVRotation(RenderHelper.YPOS, RenderHelper.instances.get().state.rotateTransform);
+        renderHelper.state.setRotateTransform(side, RenderHelper.ZNEG);
+        renderHelper.state.setUVRotation(RenderHelper.YPOS, renderHelper.state.rotateTransform);
 
         if (ClientProxy.renderPass == 0) {
             if (right) framingRenderer.renderRight(world, x, y, z, framingTable);
@@ -73,8 +75,8 @@ public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
             else framingRenderer.renderOverlayLeft(world, x, y, z, framingTable);
         }
 
-        RenderHelper.instances.get().state.clearRotateTransform();
-        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
+        renderHelper.state.clearRotateTransform();
+        renderHelper.state.clearUVRotation(RenderHelper.YPOS);
 
         return true;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/FramingTableRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/FramingTableRenderer.java
@@ -1,5 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
@@ -14,6 +15,7 @@ import com.jaquadro.minecraft.storagedrawers.util.RenderHelper;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
+@ThreadSafeISBRH(perThread = false)
 public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
 
     private CommonFramingRenderer framingRenderer = new CommonFramingRenderer();
@@ -35,12 +37,12 @@ public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
         GL11.glTranslatef(.15f, -.5f, -.5f);
         GL11.glScalef(.65f, .65f, .65f);
 
-        RenderHelper.instance.state.setUVRotation(RenderHelper.YPOS, RenderHelper.instance.state.rotateTransform);
+        RenderHelper.instances.get().state.setUVRotation(RenderHelper.YPOS, RenderHelper.instances.get().state.rotateTransform);
 
         framingRenderer.renderRight(null, 0, 0, 0, framingTable);
         framingRenderer.renderLeft(null, -1, 0, 0, framingTable);
 
-        RenderHelper.instance.state.clearUVRotation(RenderHelper.YPOS);
+        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
 
         if (!blendEnabled) GL11.glDisable(GL11.GL_BLEND);
         if (!depthMask) GL11.glDepthMask(false);
@@ -60,8 +62,8 @@ public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
 
         if (side == 2 || side == 3) right = !right;
 
-        RenderHelper.instance.state.setRotateTransform(side, RenderHelper.ZNEG);
-        RenderHelper.instance.state.setUVRotation(RenderHelper.YPOS, RenderHelper.instance.state.rotateTransform);
+        RenderHelper.instances.get().state.setRotateTransform(side, RenderHelper.ZNEG);
+        RenderHelper.instances.get().state.setUVRotation(RenderHelper.YPOS, RenderHelper.instances.get().state.rotateTransform);
 
         if (ClientProxy.renderPass == 0) {
             if (right) framingRenderer.renderRight(world, x, y, z, framingTable);
@@ -71,8 +73,8 @@ public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
             else framingRenderer.renderOverlayLeft(world, x, y, z, framingTable);
         }
 
-        RenderHelper.instance.state.clearRotateTransform();
-        RenderHelper.instance.state.clearUVRotation(RenderHelper.YPOS);
+        RenderHelper.instances.get().state.clearRotateTransform();
+        RenderHelper.instances.get().state.clearUVRotation(RenderHelper.YPOS);
 
         return true;
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ModularBoxRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ModularBoxRenderer.java
@@ -251,7 +251,7 @@ public class ModularBoxRenderer {
 
     public void renderExterior(IBlockAccess blockAccess, Block block, double x, double y, double z, double xNeg,
             double yNeg, double zNeg, double xPos, double yPos, double zPos, int connectedFlags, int cutFlags) {
-        RenderHelper renderHelper = RenderHelper.instance;
+        RenderHelper renderHelper = RenderHelper.instances.get();
 
         if ((cutFlags & CUT_YNEG) != 0) connectedFlags |= CONNECT_YNEG;
         if ((cutFlags & CUT_YPOS) != 0) connectedFlags |= CONNECT_YPOS;
@@ -459,7 +459,7 @@ public class ModularBoxRenderer {
 
     public void renderInterior(IBlockAccess blockAccess, Block block, double x, double y, double z, double xNeg,
             double yNeg, double zNeg, double xPos, double yPos, double zPos, int connectedFlags, int cutFlags) {
-        RenderHelper renderHelper = RenderHelper.instance;
+        RenderHelper renderHelper = RenderHelper.instances.get();
 
         if ((cutFlags & CUT_YNEG) != 0) connectedFlags |= PLANE_YNEG;
         if ((cutFlags & CUT_YPOS) != 0) connectedFlags |= PLANE_YPOS;
@@ -690,7 +690,7 @@ public class ModularBoxRenderer {
 
     private void renderFace(int face, IBlockAccess blockAccess, Block block, double x, double y, double z, IIcon icon,
             float r, float g, float b) {
-        RenderHelper renderHelper = RenderHelper.instance;
+        RenderHelper renderHelper = RenderHelper.instances.get();
         switch (face) {
             case FACE_YNEG:
             case FACE_YPOS:

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ModularBoxRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/ModularBoxRenderer.java
@@ -90,6 +90,8 @@ public class ModularBoxRenderer {
 
     public boolean flipOpposite;
 
+    private RenderHelper renderHelper = RenderHelper.instances.get();
+
     private void copyFrom(float[] target, float[] source) {
         target[0] = source[0];
         target[1] = source[1];
@@ -251,8 +253,6 @@ public class ModularBoxRenderer {
 
     public void renderExterior(IBlockAccess blockAccess, Block block, double x, double y, double z, double xNeg,
             double yNeg, double zNeg, double xPos, double yPos, double zPos, int connectedFlags, int cutFlags) {
-        RenderHelper renderHelper = RenderHelper.instances.get();
-
         if ((cutFlags & CUT_YNEG) != 0) connectedFlags |= CONNECT_YNEG;
         if ((cutFlags & CUT_YPOS) != 0) connectedFlags |= CONNECT_YPOS;
         if ((cutFlags & CUT_ZNEG) != 0) connectedFlags |= CONNECT_ZNEG;
@@ -459,8 +459,6 @@ public class ModularBoxRenderer {
 
     public void renderInterior(IBlockAccess blockAccess, Block block, double x, double y, double z, double xNeg,
             double yNeg, double zNeg, double xPos, double yPos, double zPos, int connectedFlags, int cutFlags) {
-        RenderHelper renderHelper = RenderHelper.instances.get();
-
         if ((cutFlags & CUT_YNEG) != 0) connectedFlags |= PLANE_YNEG;
         if ((cutFlags & CUT_YPOS) != 0) connectedFlags |= PLANE_YPOS;
         if ((cutFlags & CUT_ZNEG) != 0) connectedFlags |= CONNECT_ZNEG;
@@ -690,7 +688,6 @@ public class ModularBoxRenderer {
 
     private void renderFace(int face, IBlockAccess blockAccess, Block block, double x, double y, double z, IIcon icon,
             float r, float g, float b) {
-        RenderHelper renderHelper = RenderHelper.instances.get();
         switch (face) {
             case FACE_YNEG:
             case FACE_YPOS:

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/PanelBoxRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/PanelBoxRenderer.java
@@ -23,6 +23,8 @@ public class PanelBoxRenderer {
 
     private ModularBoxRenderer trimRenderer = new ModularBoxRenderer();
 
+    private RenderHelper renderHelper = RenderHelper.instances.get();
+
     private double trimWidth = 0.0625;
     private double trimDepth = 0;
 
@@ -58,11 +60,9 @@ public class PanelBoxRenderer {
 
     public void renderFacePanel(int face, IBlockAccess blockAccess, Block block, double x, double y, double z,
             double xNeg, double yNeg, double zNeg, double xPos, double yPos, double zPos) {
-        RenderHelper renderer = RenderHelper.instances.get();
-
         switch (face) {
             case FACE_YNEG:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg + trimDepth,
                         zNeg + trimWidth,
@@ -73,7 +73,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_YPOS:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yPos - trimDepth,
                         zNeg + trimWidth,
@@ -84,7 +84,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_ZNEG:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg + trimWidth,
                         zNeg + trimDepth,
@@ -95,7 +95,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_ZPOS:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg + trimWidth,
                         zPos - trimDepth,
@@ -106,7 +106,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_XNEG:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimDepth,
                         yNeg + trimWidth,
                         zNeg + trimWidth,
@@ -117,7 +117,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_XPOS:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimDepth,
                         yNeg + trimWidth,
                         zNeg + trimWidth,
@@ -131,11 +131,9 @@ public class PanelBoxRenderer {
 
     public void renderInteriorTrim(int face, IBlockAccess blockAccess, Block block, double x, double y, double z,
             double xNeg, double yNeg, double zNeg, double xPos, double yPos, double zPos) {
-        RenderHelper renderer = RenderHelper.instances.get();
-
         switch (face) {
             case FACE_YNEG:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg,
                         zPos - trimWidth,
@@ -143,7 +141,7 @@ public class PanelBoxRenderer {
                         yNeg + trimDepth,
                         zPos - trimWidth);
                 renderCutFace(FACE_ZNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg,
                         zNeg + trimWidth,
@@ -151,7 +149,7 @@ public class PanelBoxRenderer {
                         yNeg + trimDepth,
                         zNeg + trimWidth);
                 renderCutFace(FACE_ZPOS, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimWidth,
                         yNeg,
                         zNeg + trimWidth,
@@ -159,7 +157,7 @@ public class PanelBoxRenderer {
                         yNeg + trimDepth,
                         zPos - trimWidth);
                 renderCutFace(FACE_XNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg,
                         zNeg + trimWidth,
@@ -170,7 +168,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_YPOS:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yPos - trimDepth,
                         zPos - trimWidth,
@@ -178,7 +176,7 @@ public class PanelBoxRenderer {
                         yPos,
                         zPos - trimWidth);
                 renderCutFace(FACE_ZNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yPos - trimDepth,
                         zNeg + trimWidth,
@@ -186,7 +184,7 @@ public class PanelBoxRenderer {
                         yPos,
                         zNeg + trimWidth);
                 renderCutFace(FACE_ZPOS, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimWidth,
                         yPos - trimDepth,
                         zNeg + trimWidth,
@@ -194,7 +192,7 @@ public class PanelBoxRenderer {
                         yPos,
                         zPos - trimWidth);
                 renderCutFace(FACE_XNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yPos - trimDepth,
                         zNeg + trimWidth,
@@ -205,7 +203,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_ZNEG:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yPos - trimWidth,
                         zNeg,
@@ -213,7 +211,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zNeg + trimDepth);
                 renderCutFace(FACE_YNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg + trimWidth,
                         zNeg,
@@ -221,7 +219,7 @@ public class PanelBoxRenderer {
                         yNeg + trimWidth,
                         zNeg + trimDepth);
                 renderCutFace(FACE_YPOS, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimWidth,
                         yNeg + trimWidth,
                         zNeg,
@@ -229,7 +227,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zNeg + trimDepth);
                 renderCutFace(FACE_XNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg + trimWidth,
                         zNeg,
@@ -240,7 +238,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_ZPOS:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yPos - trimWidth,
                         zPos - trimDepth,
@@ -248,7 +246,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zPos);
                 renderCutFace(FACE_YNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg + trimWidth,
                         zPos - trimDepth,
@@ -256,7 +254,7 @@ public class PanelBoxRenderer {
                         yNeg + trimWidth,
                         zPos);
                 renderCutFace(FACE_YPOS, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimWidth,
                         yNeg + trimWidth,
                         zPos - trimDepth,
@@ -264,7 +262,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zPos);
                 renderCutFace(FACE_XNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg + trimWidth,
                         yNeg + trimWidth,
                         zPos - trimDepth,
@@ -275,7 +273,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_XNEG:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg,
                         yNeg + trimWidth,
                         zPos - trimWidth,
@@ -283,7 +281,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zPos - trimWidth);
                 renderCutFace(FACE_ZNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg,
                         yNeg + trimWidth,
                         zNeg + trimWidth,
@@ -291,7 +289,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zNeg + trimWidth);
                 renderCutFace(FACE_ZPOS, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg,
                         yPos - trimWidth,
                         zNeg + trimWidth,
@@ -299,7 +297,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zPos - trimWidth);
                 renderCutFace(FACE_YNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xNeg,
                         yNeg + trimWidth,
                         zNeg + trimWidth,
@@ -310,7 +308,7 @@ public class PanelBoxRenderer {
                 break;
 
             case FACE_XPOS:
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimDepth,
                         yNeg + trimWidth,
                         zPos - trimWidth,
@@ -318,7 +316,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zPos - trimWidth);
                 renderCutFace(FACE_ZNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimDepth,
                         yNeg + trimWidth,
                         zNeg + trimWidth,
@@ -326,7 +324,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zNeg + trimWidth);
                 renderCutFace(FACE_ZPOS, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimDepth,
                         yPos - trimWidth,
                         zNeg + trimWidth,
@@ -334,7 +332,7 @@ public class PanelBoxRenderer {
                         yPos - trimWidth,
                         zPos - trimWidth);
                 renderCutFace(FACE_YNEG, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(
+                renderHelper.setRenderBounds(
                         xPos - trimDepth,
                         yNeg + trimWidth,
                         zNeg + trimWidth,
@@ -349,133 +347,132 @@ public class PanelBoxRenderer {
     public void renderFaceTrim(int face, IBlockAccess blockAccess, Block block, double x, double y, double z,
             double xNeg, double yNeg, double zNeg, double xPos, double yPos, double zPos) {
         double unit = trimWidth;
-        RenderHelper renderer = RenderHelper.instances.get();
 
         switch (face) {
             case FACE_YNEG:
-                renderer.setRenderBounds(xNeg, yNeg, zNeg, xNeg + unit, yNeg, zNeg + unit);
+                renderHelper.setRenderBounds(xNeg, yNeg, zNeg, xNeg + unit, yNeg, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yNeg, zNeg, xPos, yNeg, zNeg + unit);
+                renderHelper.setRenderBounds(xPos - unit, yNeg, zNeg, xPos, yNeg, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yNeg, zPos - unit, xNeg + unit, yNeg, zPos);
+                renderHelper.setRenderBounds(xNeg, yNeg, zPos - unit, xNeg + unit, yNeg, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yNeg, zPos - unit, xPos, yNeg, zPos);
+                renderHelper.setRenderBounds(xPos - unit, yNeg, zPos - unit, xPos, yNeg, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
 
-                renderer.setRenderBounds(xNeg + unit, yNeg, zNeg, xPos - unit, yNeg, zNeg + unit);
+                renderHelper.setRenderBounds(xNeg + unit, yNeg, zNeg, xPos - unit, yNeg, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg + unit, yNeg, zPos - unit, xPos - unit, yNeg, zPos);
+                renderHelper.setRenderBounds(xNeg + unit, yNeg, zPos - unit, xPos - unit, yNeg, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yNeg, zNeg + unit, xNeg + unit, yNeg, zPos - unit);
+                renderHelper.setRenderBounds(xNeg, yNeg, zNeg + unit, xNeg + unit, yNeg, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yNeg, zNeg + unit, xPos, yNeg, zPos - unit);
+                renderHelper.setRenderBounds(xPos - unit, yNeg, zNeg + unit, xPos, yNeg, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
                 break;
 
             case FACE_YPOS:
-                renderer.setRenderBounds(xNeg, yPos, zNeg, xNeg + unit, yPos, zNeg + unit);
+                renderHelper.setRenderBounds(xNeg, yPos, zNeg, xNeg + unit, yPos, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yPos, zNeg, xPos, yPos, zNeg + unit);
+                renderHelper.setRenderBounds(xPos - unit, yPos, zNeg, xPos, yPos, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yPos, zPos - unit, xNeg + unit, yPos, zPos);
+                renderHelper.setRenderBounds(xNeg, yPos, zPos - unit, xNeg + unit, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yPos, zPos - unit, xPos, yPos, zPos);
+                renderHelper.setRenderBounds(xPos - unit, yPos, zPos - unit, xPos, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
 
-                renderer.setRenderBounds(xNeg + unit, yPos, zNeg, xPos - unit, yPos, zNeg + unit);
+                renderHelper.setRenderBounds(xNeg + unit, yPos, zNeg, xPos - unit, yPos, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg + unit, yPos, zPos - unit, xPos - unit, yPos, zPos);
+                renderHelper.setRenderBounds(xNeg + unit, yPos, zPos - unit, xPos - unit, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yPos, zNeg + unit, xNeg + unit, yPos, zPos - unit);
+                renderHelper.setRenderBounds(xNeg, yPos, zNeg + unit, xNeg + unit, yPos, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yPos, zNeg + unit, xPos, yPos, zPos - unit);
+                renderHelper.setRenderBounds(xPos - unit, yPos, zNeg + unit, xPos, yPos, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
                 break;
 
             case FACE_ZNEG:
-                renderer.setRenderBounds(xNeg, yNeg, zNeg, xNeg + unit, yNeg + unit, zNeg);
+                renderHelper.setRenderBounds(xNeg, yNeg, zNeg, xNeg + unit, yNeg + unit, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yNeg, zNeg, xPos, yNeg + unit, zNeg);
+                renderHelper.setRenderBounds(xPos - unit, yNeg, zNeg, xPos, yNeg + unit, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yPos - unit, zNeg, xNeg + unit, yPos, zNeg);
+                renderHelper.setRenderBounds(xNeg, yPos - unit, zNeg, xNeg + unit, yPos, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yPos - unit, zNeg, xPos, yPos, zNeg);
+                renderHelper.setRenderBounds(xPos - unit, yPos - unit, zNeg, xPos, yPos, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
 
-                renderer.setRenderBounds(xNeg + unit, yNeg, zNeg, xPos - unit, yNeg + unit, zNeg);
+                renderHelper.setRenderBounds(xNeg + unit, yNeg, zNeg, xPos - unit, yNeg + unit, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg + unit, yPos - unit, zNeg, xPos - unit, yPos, zNeg);
+                renderHelper.setRenderBounds(xNeg + unit, yPos - unit, zNeg, xPos - unit, yPos, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yNeg + unit, zNeg, xNeg + unit, yPos - unit, zNeg);
+                renderHelper.setRenderBounds(xNeg, yNeg + unit, zNeg, xNeg + unit, yPos - unit, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yNeg + unit, zNeg, xPos, yPos - unit, zNeg);
+                renderHelper.setRenderBounds(xPos - unit, yNeg + unit, zNeg, xPos, yPos - unit, zNeg);
                 renderCutFace(face, blockAccess, block, x, y, z);
                 break;
 
             case FACE_ZPOS:
-                renderer.setRenderBounds(xNeg, yNeg, zPos, xNeg + unit, yNeg + unit, zPos);
+                renderHelper.setRenderBounds(xNeg, yNeg, zPos, xNeg + unit, yNeg + unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yNeg, zPos, xPos, yNeg + unit, zPos);
+                renderHelper.setRenderBounds(xPos - unit, yNeg, zPos, xPos, yNeg + unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yPos - unit, zPos, xNeg + unit, yPos, zPos);
+                renderHelper.setRenderBounds(xNeg, yPos - unit, zPos, xNeg + unit, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yPos - unit, zPos, xPos, yPos, zPos);
+                renderHelper.setRenderBounds(xPos - unit, yPos - unit, zPos, xPos, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
 
-                renderer.setRenderBounds(xNeg + unit, yNeg, zPos, xPos - unit, yNeg + unit, zPos);
+                renderHelper.setRenderBounds(xNeg + unit, yNeg, zPos, xPos - unit, yNeg + unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg + unit, yPos - unit, zPos, xPos - unit, yPos, zPos);
+                renderHelper.setRenderBounds(xNeg + unit, yPos - unit, zPos, xPos - unit, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yNeg + unit, zPos, xNeg + unit, yPos - unit, zPos);
+                renderHelper.setRenderBounds(xNeg, yNeg + unit, zPos, xNeg + unit, yPos - unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos - unit, yNeg + unit, zPos, xPos, yPos - unit, zPos);
+                renderHelper.setRenderBounds(xPos - unit, yNeg + unit, zPos, xPos, yPos - unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
                 break;
 
             case FACE_XNEG:
-                renderer.setRenderBounds(xNeg, yNeg, zNeg, xNeg, yNeg + unit, zNeg + unit);
+                renderHelper.setRenderBounds(xNeg, yNeg, zNeg, xNeg, yNeg + unit, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yPos - unit, zNeg, xNeg, yPos, zNeg + unit);
+                renderHelper.setRenderBounds(xNeg, yPos - unit, zNeg, xNeg, yPos, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yNeg, zPos - unit, xNeg, yNeg + unit, zPos);
+                renderHelper.setRenderBounds(xNeg, yNeg, zPos - unit, xNeg, yNeg + unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yPos - unit, zPos - unit, xNeg, yPos, zPos);
+                renderHelper.setRenderBounds(xNeg, yPos - unit, zPos - unit, xNeg, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
 
-                renderer.setRenderBounds(xNeg, yNeg + unit, zNeg, xNeg, yPos - unit, zNeg + unit);
+                renderHelper.setRenderBounds(xNeg, yNeg + unit, zNeg, xNeg, yPos - unit, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yNeg + unit, zPos - unit, xNeg, yPos - unit, zPos);
+                renderHelper.setRenderBounds(xNeg, yNeg + unit, zPos - unit, xNeg, yPos - unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yNeg, zNeg + unit, xNeg, yNeg + unit, zPos - unit);
+                renderHelper.setRenderBounds(xNeg, yNeg, zNeg + unit, xNeg, yNeg + unit, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xNeg, yPos - unit, zNeg + unit, xNeg, yPos, zPos - unit);
+                renderHelper.setRenderBounds(xNeg, yPos - unit, zNeg + unit, xNeg, yPos, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
                 break;
 
             case FACE_XPOS:
-                renderer.setRenderBounds(xPos, yNeg, zNeg, xPos, yNeg + unit, zNeg + unit);
+                renderHelper.setRenderBounds(xPos, yNeg, zNeg, xPos, yNeg + unit, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos, yPos - unit, zNeg, xPos, yPos, zNeg + unit);
+                renderHelper.setRenderBounds(xPos, yPos - unit, zNeg, xPos, yPos, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos, yNeg, zPos - unit, xPos, yNeg + unit, zPos);
+                renderHelper.setRenderBounds(xPos, yNeg, zPos - unit, xPos, yNeg + unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos, yPos - unit, zPos - unit, xPos, yPos, zPos);
+                renderHelper.setRenderBounds(xPos, yPos - unit, zPos - unit, xPos, yPos, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
 
-                renderer.setRenderBounds(xPos, yNeg + unit, zNeg, xPos, yPos - unit, zNeg + unit);
+                renderHelper.setRenderBounds(xPos, yNeg + unit, zNeg, xPos, yPos - unit, zNeg + unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos, yNeg + unit, zPos - unit, xPos, yPos - unit, zPos);
+                renderHelper.setRenderBounds(xPos, yNeg + unit, zPos - unit, xPos, yPos - unit, zPos);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos, yNeg, zNeg + unit, xPos, yNeg + unit, zPos - unit);
+                renderHelper.setRenderBounds(xPos, yNeg, zNeg + unit, xPos, yNeg + unit, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
-                renderer.setRenderBounds(xPos, yPos - unit, zNeg + unit, xPos, yPos, zPos - unit);
+                renderHelper.setRenderBounds(xPos, yPos - unit, zNeg + unit, xPos, yPos, zPos - unit);
                 renderCutFace(face, blockAccess, block, x, y, z);
                 break;
         }
     }
 
     private void renderCutFace(int face, IBlockAccess blockAccess, Block block, double x, double y, double z) {
-        RenderHelper.instances.get().renderFace(
+        renderHelper.renderFace(
                 face,
                 blockAccess,
                 block,
@@ -489,7 +486,7 @@ public class PanelBoxRenderer {
     }
 
     private void renderPaneltFace(int face, IBlockAccess blockAccess, Block block, double x, double y, double z) {
-        RenderHelper.instances.get().renderFace(
+        renderHelper.renderFace(
                 face,
                 blockAccess,
                 block,

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/PanelBoxRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/PanelBoxRenderer.java
@@ -58,7 +58,7 @@ public class PanelBoxRenderer {
 
     public void renderFacePanel(int face, IBlockAccess blockAccess, Block block, double x, double y, double z,
             double xNeg, double yNeg, double zNeg, double xPos, double yPos, double zPos) {
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         switch (face) {
             case FACE_YNEG:
@@ -131,7 +131,7 @@ public class PanelBoxRenderer {
 
     public void renderInteriorTrim(int face, IBlockAccess blockAccess, Block block, double x, double y, double z,
             double xNeg, double yNeg, double zNeg, double xPos, double yPos, double zPos) {
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         switch (face) {
             case FACE_YNEG:
@@ -349,7 +349,7 @@ public class PanelBoxRenderer {
     public void renderFaceTrim(int face, IBlockAccess blockAccess, Block block, double x, double y, double z,
             double xNeg, double yNeg, double zNeg, double xPos, double yPos, double zPos) {
         double unit = trimWidth;
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         switch (face) {
             case FACE_YNEG:
@@ -475,7 +475,7 @@ public class PanelBoxRenderer {
     }
 
     private void renderCutFace(int face, IBlockAccess blockAccess, Block block, double x, double y, double z) {
-        RenderHelper.instance.renderFace(
+        RenderHelper.instances.get().renderFace(
                 face,
                 blockAccess,
                 block,
@@ -489,7 +489,7 @@ public class PanelBoxRenderer {
     }
 
     private void renderPaneltFace(int face, IBlockAccess blockAccess, Block block, double x, double y, double z) {
-        RenderHelper.instance.renderFace(
+        RenderHelper.instances.get().renderFace(
                 face,
                 blockAccess,
                 block,

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TrimCustomRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TrimCustomRenderer.java
@@ -1,5 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
@@ -13,6 +14,7 @@ import com.jaquadro.minecraft.storagedrawers.client.renderer.common.CommonTrimRe
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
+@ThreadSafeISBRH(perThread = false)
 public class TrimCustomRenderer implements ISimpleBlockRenderingHandler {
 
     private CommonTrimRenderer commonRender = new CommonTrimRenderer();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TrimCustomRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TrimCustomRenderer.java
@@ -1,12 +1,12 @@
 package com.jaquadro.minecraft.storagedrawers.client.renderer;
 
-import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockTrimCustom;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityTrim;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/common/CommonDrawerRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/common/CommonDrawerRenderer.java
@@ -32,7 +32,7 @@ public class CommonDrawerRenderer {
         panelRenderer.setTrimColor(ModularBoxRenderer.COLOR_WHITE);
         panelRenderer.setPanelColor(ModularBoxRenderer.COLOR_WHITE);
 
-        RenderHelper renderHelper = RenderHelper.instance;
+        RenderHelper renderHelper = RenderHelper.instances.get();
         if (world != null) renderHelper.setColorAndBrightness(world, block, x, y, z);
 
         renderHelper.state.setRotateTransform(RenderHelper.ZNEG, direction);
@@ -44,7 +44,7 @@ public class CommonDrawerRenderer {
     }
 
     private void end() {
-        RenderHelper renderHelper = RenderHelper.instance;
+        RenderHelper renderHelper = RenderHelper.instances.get();
 
         renderHelper.state.clearRotateTransform();
         renderHelper.state.clearUVRotation(RenderHelper.YPOS);
@@ -154,7 +154,7 @@ public class CommonDrawerRenderer {
             renderHelper.renderFace(RenderHelper.ZNEG, world, block, x, y, z, trimShadow);
             renderHelper.setRenderBounds(unit7, unit7, depth + trimDepth, unit9, unit9, 1);
             renderHelper.renderFace(RenderHelper.ZNEG, world, block, x, y, z, trimShadow);
-        } else RenderHelper.instance.renderEmptyPlane(x, y, z);
+        } else RenderHelper.instances.get().renderEmptyPlane(x, y, z);
 
         end();
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/common/CommonFramingRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/common/CommonFramingRenderer.java
@@ -80,7 +80,7 @@ public class CommonFramingRenderer {
             double[][] baseBoundsY, boolean left) {
         IIcon iconOverlay = block.getIconOverlay(left);
 
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         for (double[] bound : baseBoundsY) {
             renderer.setRenderBounds(bound);
@@ -99,7 +99,7 @@ public class CommonFramingRenderer {
     private void renderTableBox(IBlockAccess blockAccess, int x, int y, int z, BlockFramingTable block,
             double[][] baseBoundsY, double[][] trimBoundsY, double[][] trimBoundsZ, double[][] trimBoundsX,
             boolean left) {
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         IIcon iconSurface = block.getIconBase();
         IIcon iconTrim = block.getIconTrim();
@@ -132,7 +132,7 @@ public class CommonFramingRenderer {
 
     private void renderFoot(IBlockAccess blockAccess, int x, int y, int z, BlockFramingTable block, IIcon icon,
             boolean left) {
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         float oldColor = renderer.state.colorMultYPos;
         renderer.state.colorMultYPos = .9f;
@@ -152,7 +152,7 @@ public class CommonFramingRenderer {
 
     private void renderLegs(IBlockAccess blockAccess, int x, int y, int z, BlockFramingTable block, IIcon icon,
             boolean left) {
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         for (int i = 2; i < 6; i++) renderer.state.setUVRotation(i, RenderHelperState.ROTATE90);
 
@@ -169,7 +169,7 @@ public class CommonFramingRenderer {
 
     private void renderBraces(IBlockAccess blockAccess, int x, int y, int z, BlockFramingTable block, IIcon icon,
             boolean left) {
-        RenderHelper renderer = RenderHelper.instance;
+        RenderHelper renderer = RenderHelper.instances.get();
 
         float oldColor = renderer.state.colorMultYPos;
         renderer.state.colorMultYPos = .85f;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/common/CommonTrimRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/common/CommonTrimRenderer.java
@@ -22,7 +22,7 @@ public class CommonTrimRenderer {
         panelRenderer.setTrimColor(ModularBoxRenderer.COLOR_WHITE);
         panelRenderer.setPanelColor(ModularBoxRenderer.COLOR_WHITE);
 
-        RenderHelper renderHelper = RenderHelper.instance;
+        RenderHelper renderHelper = RenderHelper.instances.get();
         if (world != null) renderHelper.setColorAndBrightness(world, block, x, y, z);
 
         return renderHelper;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/RenderHelper.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/RenderHelper.java
@@ -31,8 +31,7 @@ public class RenderHelper {
     private RenderHelperLL llHelper = new RenderHelperLL(state);
 
     private float[] colorScratch = new float[3];
-
-    public static RenderHelper instance = new RenderHelper();
+    public static final ThreadLocal<RenderHelper> instances = ThreadLocal.withInitial(RenderHelper::new);
 
     public static void calculateBaseColor(float[] target, int color) {
         float r = (float) (color >> 16 & 255) / 255f;


### PR DESCRIPTION
See title ^

Mostly just adds `ThreadSafeISBRH` to every ISBRH, and converts a problematic `RenderHelper` to not use a static singleton and instead use ThreadLocal.

I've tested normal drawers with most every upgrade, as well as drawer controllers/slaves, trim, and the framing table.