### PR TITLE
Non gtnh recipes

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModRecipes.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ModRecipes.java
@@ -203,8 +203,16 @@ public class ModRecipes {
                         'w',
                         "ingotGold"));
 
-        // GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ModItems.upgradeTemplate, 2), "xxx", "xyx", "xxx",
-        // 'x', "stickWood", 'y', "drawerBasic"));
+        GameRegistry.addRecipe(
+                new ShapedOreRecipe(
+                        new ItemStack(ModItems.upgradeTemplate, 2),
+                        "xxx",
+                        "xyx",
+                        "xxx",
+                        'x',
+                        "stickWood",
+                        'y',
+                        "drawerBasic"));
 
         if (config.cache.enableStorageUpgrades) {
             GameRegistry.addRecipe(

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/GTNHIntegrationModule.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/GTNHIntegrationModule.java
@@ -7,7 +7,7 @@ import cpw.mods.fml.common.Loader;
 
 public class GTNHIntegrationModule extends IntegrationModule {
 
-    private static final boolean GTNHEnabled = (Loader.isModLoaded("gregtech")
+    private static final boolean GTNHEnabled = (Loader.isModLoaded("dreamcraft")
             && StorageDrawers.config.integrationConfig.isGTNHEnabled());
 
     public static boolean isEnabled() {


### PR DESCRIPTION
Changes the GTNH integration module to use the `dreamcraft` mod ID instead of `gregtech`. In case if Storage Drawers is installed alongside gregtech in other packs than GTNH, it shouldn't trigger the GTNH specific things.

Also uncomments the default recipe for upgrade templates(See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17189).

Doesn't actually change anything within GTNH, purely for usage outside the pack.