### PR TITLE
Thread Safe Rendering Fixes

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawersCustom.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawersCustom.java
@@ -13,7 +13,6 @@ import net.minecraft.world.World;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.pack.BlockType;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
-import com.jaquadro.minecraft.storagedrawers.core.ClientProxy;
 import com.jaquadro.minecraft.storagedrawers.item.ItemCustomDrawers;
 
 import cpw.mods.fml.relauncher.Side;
@@ -55,7 +54,6 @@ public class BlockDrawersCustom extends BlockDrawers {
 
     @Override
     public boolean canRenderInPass(int pass) {
-        ClientProxy.renderPass = pass;
         return true;
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockFramingTable.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockFramingTable.java
@@ -17,7 +17,6 @@ import net.minecraft.world.World;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityFramingTable;
-import com.jaquadro.minecraft.storagedrawers.core.ClientProxy;
 import com.jaquadro.minecraft.storagedrawers.core.ModBlocks;
 import com.jaquadro.minecraft.storagedrawers.core.ModCreativeTabs;
 import com.jaquadro.minecraft.storagedrawers.core.handlers.GuiHandler;
@@ -106,7 +105,6 @@ public class BlockFramingTable extends BlockContainer {
 
     @Override
     public boolean canRenderInPass(int pass) {
-        ClientProxy.renderPass = pass;
         return true;
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrimCustom.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockTrimCustom.java
@@ -15,7 +15,6 @@ import net.minecraft.world.World;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityTrim;
-import com.jaquadro.minecraft.storagedrawers.core.ClientProxy;
 import com.jaquadro.minecraft.storagedrawers.item.ItemCustomTrim;
 
 import cpw.mods.fml.relauncher.Side;
@@ -46,7 +45,6 @@ public class BlockTrimCustom extends BlockTrim implements ITileEntityProvider {
 
     @Override
     public boolean canRenderInPass(int pass) {
-        ClientProxy.renderPass = pass;
         return true;
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersCustomRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/DrawersCustomRenderer.java
@@ -5,17 +5,19 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawersCustom;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.common.CommonDrawerRenderer;
-import com.jaquadro.minecraft.storagedrawers.core.ClientProxy;
 
+@ThreadSafeISBRH(perThread = true)
 public class DrawersCustomRenderer extends DrawersRenderer {
 
-    private CommonDrawerRenderer commonRender = new CommonDrawerRenderer();
+    private final CommonDrawerRenderer commonRender = new CommonDrawerRenderer();
 
     @Override
     protected void renderBaseBlock(IBlockAccess world, TileEntityDrawers tile, int x, int y, int z, BlockDrawers block,
@@ -39,9 +41,9 @@ public class DrawersCustomRenderer extends DrawersRenderer {
         if (panelIcon == null) panelIcon = custom.getDefaultFaceIcon();
         if (frontIcon == null) frontIcon = custom.getDefaultFaceIcon();
 
-        if (ClientProxy.renderPass == 0)
+        if (ForgeHooksClient.getWorldRenderPass() == 0)
             commonRender.renderBasePass(world, x, y, z, custom, tile.getDirection(), panelIcon, trimIcon, frontIcon);
-        else if (ClientProxy.renderPass == 1)
+        else if (ForgeHooksClient.getWorldRenderPass() == 1)
             commonRender.renderOverlayPass(world, x, y, z, custom, tile.getDirection(), trimIcon, frontIcon);
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/FramingTableRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/FramingTableRenderer.java
@@ -3,6 +3,7 @@ package com.jaquadro.minecraft.storagedrawers.client.renderer;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 
 import org.lwjgl.opengl.GL11;
 
@@ -10,7 +11,6 @@ import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.BlockFramingTable;
 import com.jaquadro.minecraft.storagedrawers.client.renderer.common.CommonFramingRenderer;
-import com.jaquadro.minecraft.storagedrawers.core.ClientProxy;
 import com.jaquadro.minecraft.storagedrawers.util.RenderHelper;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
@@ -67,10 +67,10 @@ public class FramingTableRenderer implements ISimpleBlockRenderingHandler {
         renderHelper.state.setRotateTransform(side, RenderHelper.ZNEG);
         renderHelper.state.setUVRotation(RenderHelper.YPOS, renderHelper.state.rotateTransform);
 
-        if (ClientProxy.renderPass == 0) {
+        if (ForgeHooksClient.getWorldRenderPass() == 0) {
             if (right) framingRenderer.renderRight(world, x, y, z, framingTable);
             else framingRenderer.renderLeft(world, x, y, z, framingTable);
-        } else if (ClientProxy.renderPass == 1) {
+        } else if (ForgeHooksClient.getWorldRenderPass() == 1) {
             if (right) framingRenderer.renderOverlayRight(world, x, y, z, framingTable);
             else framingRenderer.renderOverlayLeft(world, x, y, z, framingTable);
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TrimCustomRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TrimCustomRenderer.java
@@ -14,7 +14,7 @@ import com.jaquadro.minecraft.storagedrawers.client.renderer.common.CommonTrimRe
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
-@ThreadSafeISBRH(perThread = false)
+@ThreadSafeISBRH(perThread = true)
 public class TrimCustomRenderer implements ISimpleBlockRenderingHandler {
 
     private CommonTrimRenderer commonRender = new CommonTrimRenderer();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ClientProxy.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/core/ClientProxy.java
@@ -22,7 +22,6 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
 
 public class ClientProxy extends CommonProxy {
 
-    public static int renderPass = 0;
     private DrawersItemRenderer itemRenderer = new DrawersItemRenderer();
     private TrimItemRender trimItemRenderer = new TrimItemRender();
 


### PR DESCRIPTION
Adds explicit ThreadSafeISBRH annotation to framed drawers renderer, making it perThread, as well as removes static render pass caching from ClientProxy and replaces it with the Forge method that Angelica overrides