### PR TITLE
Cleanup drawer item dropping code and add new "mixed" behavior

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,4 +9,5 @@ dependencies {
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly('curse.maven:refined-relocation-75811:2262970')
     compileOnly('curse.maven:minetweaker3-224029:2255759')
+    compileOnly("com.github.GTNewHorizons:Avaritia:1.67:dev")
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -684,9 +684,9 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
     }
 
     /**
-     * Drops an ItemStack with an "illegal" size that will contain all the items in one stack. The downside of this method is
-     * that if the ItemStack is still on the ground when the chunk is saved (stopping game, or going away). It will not
-     * save the size of the ItemStack correctly since the size is stored as a byte (max 255)
+     * Drops an ItemStack with an "illegal" size that will contain all the items in one stack. The downside of this
+     * method is that if the ItemStack is still on the ground when the chunk is saved (stopping game, or going away). It
+     * will not save the size of the ItemStack correctly since the size is stored as a byte (max 255)
      * {@link net.minecraft.item.ItemStack#writeToNBT(NBTTagCompound)}, ITEMS WILL BE LOST !!
      */
     private static void dropBigStackInWorld(World world, int x, int y, int z, ItemStack stack) {

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -613,14 +613,14 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
             if (!tile.isVending()) {
                 switch (StorageDrawers.config.cache.breakDrawerDropMode) {
                     case "merge":
-                        dropMergedStacks(world, x, y, z, tile);
+                        dropMergedStacks(tile, world, x, y, z);
                         break;
                     case "destroy":
-                        dropStacksAndDestroyExcess(world, x, y, z, tile);
+                        dropStacksAndDestroyExcess(tile, world, x, y, z);
                         break;
                     case "cluster":
                         if (Loader.isModLoaded("Avaritia")) {
-                            dropAvaritiaClusters(world, x, y, z, tile);
+                            dropAvaritiaClusters(tile, world, x, y, z);
                         }
                     case "default":
                     default:
@@ -680,7 +680,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
      * save the size of the ItemStack correctly since the size is stored as a byte (max 255)
      * {@link net.minecraft.item.ItemStack#writeToNBT(NBTTagCompound)}, ITEMS WILL BE LOST !!
      */
-    private static void dropMergedStacks(World world, int x, int y, int z, TileEntityDrawers tile) {
+    private static void dropMergedStacks(TileEntityDrawers tile, World world, int x, int y, int z) {
         for (int i = 0; i < tile.getDrawerCount(); i++) {
             if (!tile.isDrawerEnabled(i)) continue;
             IDrawer drawer = tile.getDrawer(i);
@@ -697,7 +697,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
     /**
      * Drops normal stacks but voids above 4096 items.
      */
-    private static void dropStacksAndDestroyExcess(World world, int x, int y, int z, TileEntityDrawers tile) {
+    private static void dropStacksAndDestroyExcess(TileEntityDrawers tile, World world, int x, int y, int z) {
         int maxDropNum = 4096 / tile.getDrawerCount();
         for (int i = 0; i < tile.getDrawerCount(); i++) {
             if (!tile.isDrawerEnabled(i)) continue;
@@ -711,7 +711,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
      * Drops Avaritia matter clusters with all the items.
      */
     @Optional.Method(modid = "Avaritia")
-    private static void dropAvaritiaClusters(World world, int x, int y, int z, TileEntityDrawers tile) {
+    private static void dropAvaritiaClusters(TileEntityDrawers tile, World world, int x, int y, int z) {
         for (int i = 0; i < tile.getDrawerCount(); i++) {
             List<ItemStack> stacks = new ArrayList<>();
             forEachSplitStackOfSubDrawer(tile, i, stacks::add);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -703,8 +703,8 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
             if (!tile.isDrawerEnabled(i)) continue;
             IDrawer drawer = tile.getDrawer(i);
             if (drawer.getStoredItemCount() > maxDropNum) drawer.setStoredItemCount(maxDropNum);
-            forEachSplitStackOfSubDrawer(tile, i, stack -> spawnStackInWorld(world, x, y, z, stack));
         }
+        dropAllStacksOfDrawer(tile, world, x, y, z);
     }
 
     /**

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -697,10 +697,10 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
     }
 
     /**
-     * Drops normal stacks but voids above 2048 items.
+     * Drops normal stacks but voids above 4096 items.
      */
     private static void dropStacksAndDestroyExcess(World world, int x, int y, int z, TileEntityDrawers tile) {
-        int maxDropNum = 2048 / tile.getDrawerCount();
+        int maxDropNum = 4096 / tile.getDrawerCount();
         for (int i = 0; i < tile.getDrawerCount(); i++) {
             if (!tile.isDrawerEnabled(i)) continue;
             IDrawer drawer = tile.getDrawer(i);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -583,20 +583,6 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
         return super.removedByPlayer(world, player, x, y, z);
     }
 
-    private static void dropBigStackInWorld(World world, int x, int y, int z, ItemStack stack) {
-        if (stack == null || stack.stackSize <= 0) return;
-        Random rand = world.rand;
-
-        float ex = rand.nextFloat() * .8f + .1f;
-        float ey = rand.nextFloat() * .8f + .1f;
-        float ez = rand.nextFloat() * .8f + .1f;
-
-        EntityItem entity = new EntityItem(world, x + ex, y + ey, z + ez, stack);
-        if (stack.hasTagCompound())
-            entity.getEntityItem().setTagCompound((NBTTagCompound) stack.getTagCompound().copy());
-        world.spawnEntityInWorld(entity);
-    }
-
     @Override
     public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
         TileEntityDrawers tile = getTileEntity(world, x, y, z);
@@ -695,6 +681,25 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
                 forEachSplitStackOfSubDrawer(tile, i, stack -> spawnStackInWorld(world, x, y, z, stack));
             }
         }
+    }
+
+    /**
+     * Drops an ItemStack with an "illegal" size that will contain all the items in one stack. The downside of this method is
+     * that if the ItemStack is still on the ground when the chunk is saved (stopping game, or going away). It will not
+     * save the size of the ItemStack correctly since the size is stored as a byte (max 255)
+     * {@link net.minecraft.item.ItemStack#writeToNBT(NBTTagCompound)}, ITEMS WILL BE LOST !!
+     */
+    private static void dropBigStackInWorld(World world, int x, int y, int z, ItemStack stack) {
+        if (stack == null || stack.stackSize <= 0) return;
+        Random rand = world.rand;
+        float ex = rand.nextFloat() * 0.8f + 0.1f;
+        float ey = rand.nextFloat() * 0.8f + 0.1f;
+        float ez = rand.nextFloat() * 0.8f + 0.1f;
+        EntityItem entity = new EntityItem(world, x + ex, y + ey, z + ez, stack);
+        if (stack.hasTagCompound()) {
+            entity.getEntityItem().setTagCompound((NBTTagCompound) stack.getTagCompound().copy());
+        }
+        world.spawnEntityInWorld(entity);
     }
 
     /**

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -322,7 +322,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
             float hitY, float hitZ) {
-        if (world.isRemote && Minecraft.getMinecraft().getSystemTime() == ignoreEventTime) {
+        if (world.isRemote && Minecraft.getSystemTime() == ignoreEventTime) {
             ignoreEventTime = 0;
             return false;
         }
@@ -334,24 +334,22 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
 
         if (StorageDrawers.config.cache.debugTrace) {
             FMLLog.log(StorageDrawers.MOD_ID, Level.INFO, "BlockDrawers.onBlockActivated");
-            FMLLog.log(StorageDrawers.MOD_ID, Level.INFO, (item == null) ? "  null item" : "  " + item.toString());
+            FMLLog.log(StorageDrawers.MOD_ID, Level.INFO, (item == null) ? "  null item" : "  " + item);
         }
 
         if (item != null && item.getItem() != null) {
             if (item.getItem() instanceof ItemTrim && player.isSneaking()) {
                 if (!retrimBlock(world, x, y, z, item)) return false;
 
-                if (player != null && !player.capabilities.isCreativeMode) {
+                if (!player.capabilities.isCreativeMode) {
                     if (--item.stackSize <= 0)
                         player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
                 }
 
                 return true;
             }
-            /**
-             * Gee, it'd be nice if we could make all of these Items descend from one thing, almost like children and it
-             * would great if we could just find if it was an instance of said thing. Crazy concept!
-             */
+            // Gee, it'd be nice if we could make all of these Items descend from one thing, almost like children and it
+            // would great if we could just find if it was an instance of said thing. Crazy concept!
             else if (item.getItem() == ModItems.upgrade || item.getItem() == ModItems.upgradeStatus
                     || item.getItem() == ModItems.upgradeVoid
                     || item.getItem() == ModItems.upgradeCreative
@@ -364,7 +362,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
 
                         world.markBlockForUpdate(x, y, z);
 
-                        if (player != null && !player.capabilities.isCreativeMode) {
+                        if (!player.capabilities.isCreativeMode) {
                             if (--item.stackSize <= 0)
                                 player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
                         }
@@ -480,7 +478,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
                             StorageDrawers.config.cache.invertShift));
 
             if (StorageDrawers.config.cache.debugTrace)
-                FMLLog.log(StorageDrawers.MOD_ID, Level.INFO, "BlockDrawers.onBlockClicked with " + posn.toString());
+                FMLLog.log(StorageDrawers.MOD_ID, Level.INFO, "BlockDrawers.onBlockClicked with " + posn);
         }
     }
 
@@ -506,19 +504,19 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
         int slot = getDrawerSlot(side, hitX, hitY, hitZ);
         IDrawer drawer = tileDrawers.getDrawer(slot);
 
-        ItemStack item = null;
+        final ItemStack item;
         // if invertSHift is true this will happen when the player is not shifting
         if (player.isSneaking() != invertShift)
             item = tileDrawers.takeItemsFromSlot(slot, drawer.getStoredItemStackSize());
         else item = tileDrawers.takeItemsFromSlot(slot, 1);
 
         if (StorageDrawers.config.cache.debugTrace)
-            FMLLog.log(StorageDrawers.MOD_ID, Level.INFO, (item == null) ? "  null item" : "  " + item.toString());
+            FMLLog.log(StorageDrawers.MOD_ID, Level.INFO, (item == null) ? "  null item" : "  " + item);
 
         if (item != null && item.stackSize > 0) {
             if (!player.inventory.addItemStackToInventory(item)) {
                 ForgeDirection dir = ForgeDirection.getOrientation(side);
-                dropItemStack(world, x + dir.offsetX, y, z + dir.offsetZ, player, item);
+                dropItemStack(world, x + dir.offsetX, y, z + dir.offsetZ, item);
                 world.markBlockForUpdate(x, y, z);
             } else world.playSoundEffect(
                     x + .5f,
@@ -547,7 +545,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
 
         world.markBlockForUpdate(x, y, z);
 
-        if (world.isRemote) ignoreEventTime = Minecraft.getMinecraft().getSystemTime();
+        if (world.isRemote) ignoreEventTime = Minecraft.getSystemTime();
 
         return true;
     }
@@ -562,12 +560,10 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
         }
 
         if (getTileEntity(world, x, y, z) == null) return true;
-        if (side.ordinal() != getTileEntity(world, x, y, z).getDirection()) return true;
-
-        return false;
+        return side.ordinal() != getTileEntity(world, x, y, z).getDirection();
     }
 
-    private void dropItemStack(World world, int x, int y, int z, EntityPlayer player, ItemStack stack) {
+    private void dropItemStack(World world, int x, int y, int z, ItemStack stack) {
         EntityItem entity = new EntityItem(world, x + .5f, y + .5f, z + .5f, stack);
         entity.addVelocity(-entity.motionX, -entity.motionY, -entity.motionZ);
         world.spawnEntityInWorld(entity);
@@ -578,13 +574,11 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
         if (world.isRemote && player.capabilities.isCreativeMode) {
             TileEntityDrawers tile = getTileEntity(world, x, y, z);
             MovingObjectPosition posn = Minecraft.getMinecraft().objectMouseOver;
-
             if (tile.getDirection() == posn.sideHit) {
                 onBlockClicked(world, x, y, z, player);
                 return false;
             }
         }
-
         return super.removedByPlayer(world, player, x, y, z);
     }
 
@@ -738,7 +732,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
     @Override
     public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean willHarvest) {
         if (willHarvest) return true;
-        return super.removedByPlayer(world, player, x, y, z, willHarvest);
+        return super.removedByPlayer(world, player, x, y, z, false);
     }
 
     @Override
@@ -751,7 +745,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
         ItemStack dropStack = getMainDrop(world, x, y, z, metadata);
 
-        ArrayList<ItemStack> drops = new ArrayList<ItemStack>();
+        ArrayList<ItemStack> drops = new ArrayList<>();
         drops.add(dropStack);
 
         TileEntityDrawers tile = getTileEntity(world, x, y, z);

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -618,6 +618,9 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
                     case "destroy":
                         dropStacksAndDestroyExcess(tile, world, x, y, z);
                         break;
+                    case "mixed":
+                        dropStacksMixedBehavior(tile, world, x, y, z);
+                        break;
                     case "cluster":
                         if (Loader.isModLoaded("Avaritia")) {
                             dropAvaritiaClusters(tile, world, x, y, z);
@@ -705,6 +708,35 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
             if (drawer.getStoredItemCount() > maxDropNum) drawer.setStoredItemCount(maxDropNum);
         }
         dropAllStacksOfDrawer(tile, world, x, y, z);
+    }
+
+    private static void dropStacksMixedBehavior(TileEntityDrawers tile, World world, int x, int y, int z) {
+        final int stacksToSpawn = countAmountOfStacksToSpawn(tile);
+        if (stacksToSpawn <= 64) {
+            dropAllStacksOfDrawer(tile, world, x, y, z);
+        } else if (Loader.isModLoaded("Avaritia")) {
+            dropAvaritiaClusters(tile, world, x, y, z);
+        } else {
+            dropMergedStacks(tile, world, x, y, z);
+        }
+    }
+
+    /**
+     * Counts the amount of stacks that would drop if we were to break this drawer.
+     */
+    private static int countAmountOfStacksToSpawn(TileEntityDrawers tile) {
+        int stackCount = 0;
+        for (int i = 0; i < tile.getDrawerCount(); i++) {
+            if (!tile.isDrawerEnabled(i)) continue;
+            IDrawer drawer = tile.getDrawer(i);
+            final ItemStack storedItem = drawer.getStoredItemPrototype();
+            if (storedItem == null) continue;
+            final int maxStackSize = storedItem.getMaxStackSize();
+            final int storedItemCount = drawer.getStoredItemCount();
+            stackCount += storedItemCount / maxStackSize;
+            if (storedItemCount % maxStackSize != 0) stackCount++;
+        }
+        return stackCount;
     }
 
     /**

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -518,6 +518,9 @@ public abstract class TileEntityDrawers extends BaseTileEntity implements IDrawe
         materialTrim = material;
     }
 
+    /**
+     * Returns an ItemStack that will have a maximum size of {@link ItemStack#getMaxStackSize()}
+     */
     public ItemStack takeItemsFromSlot(int slot, int count) {
         if (slot < 0 || slot >= getDrawerCount()) return null;
 
@@ -537,6 +540,9 @@ public abstract class TileEntityDrawers extends BaseTileEntity implements IDrawe
         return stack;
     }
 
+    /**
+     * Returns an ItemStack that will have a maximum size of {@link ItemStack#getMaxStackSize()}
+     */
     protected ItemStack getItemsFromSlot(int slot, int count) {
         if (drawers[slot].isEmpty()) return null;
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/config/ConfigManager.java
@@ -395,9 +395,9 @@ public class ConfigManager {
                 .get(
                         Configuration.CATEGORY_GENERAL,
                         "breakDrawerDropMode",
-                        "merge",
-                        "Select: default, merge, destroy and cluster. ",
-                        new String[] { "default", "destroy", "merge", "cluster" })
+                        "mixed",
+                        "Select: default, mixed, merge, destroy and cluster. ",
+                        new String[] { "default", "mixed", "merge", "destroy", "cluster" })
                 .setLanguageKey(LANG_PREFIX + "prop.breakDrawerDropMode").getString();
 
         cache.enableAE2Integration = config.get(sectionIntegration.getQualifiedName(), "enableAE2", true)


### PR DESCRIPTION
I added a new "mixed" config that will drop all the items if it's less than 64 stacks, else it will try to spawn Avaritia clusters and if it can't it will default to dropping a big item stacks with all items in one stack.

Notable mentions :

The code for spawning stacks in the world previously dropped stacks of random size from 20 to 30 for some reasons. I changed it to drop stacks of the maximum size possible for the item.