### PR TITLE
Impr(client): cache EntityItem in renderFancyItem for Fancy Rendering

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/client/renderer/TileEntityDrawersRenderer.java
@@ -45,6 +45,8 @@ public class TileEntityDrawersRenderer extends TileEntitySpecialRenderer {
     private static final ResourceLocation RES_ITEM_GLINT = new ResourceLocation(
             "textures/misc/enchanted_item_glint.png");
 
+    private static final String ENT_ITEM_CACHE_KEY = "entItemCache";
+
     private final RenderItem itemRenderer = new RenderItem() {
 
         private final RenderBlocks renderBlocksRi = new RenderBlocks();
@@ -513,13 +515,25 @@ public class TileEntityDrawersRenderer extends TileEntitySpecialRenderer {
         GL11.glDisable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_LIGHTING);
 
+        IDrawer drawer = tile.getDrawer(slot);
         try {
-            EntityItem itemEnt = new EntityItem(null, 0, 0, 0, itemStack);
-            itemEnt.hoverStart = 0;
+            EntityItem itemEnt = getCachedEntityItem(drawer, itemStack);
             itemRenderer.doRender(itemEnt, 0, 0, 0, 0, 0);
-        } catch (Exception e) {}
+        } catch (Exception ignored) {}
 
         GL11.glPopMatrix();
+    }
+
+    private EntityItem getCachedEntityItem(IDrawer drawer, ItemStack itemStack) {
+        EntityItem cachedEntityItem, newEntityItem;
+        cachedEntityItem = (EntityItem) drawer.getExtendedData(ENT_ITEM_CACHE_KEY);
+        if (cachedEntityItem != null && ItemStack.areItemStacksEqual(cachedEntityItem.getEntityItem(), itemStack)) {
+            return cachedEntityItem;
+        }
+        newEntityItem = new EntityItem(null, 0, 0, 0, itemStack);
+        newEntityItem.hoverStart = 0;
+        drawer.setExtendedData(ENT_ITEM_CACHE_KEY, newEntityItem);
+        return newEntityItem;
     }
 
     private void renderFastItem(ItemStack itemStack, TileEntityDrawers tile, int slot, ForgeDirection side, float depth,


### PR DESCRIPTION
When `itemRenderType=fancy` is set in `StorageDrawers.cfg`, StorageDrawers uses an `EntityItem` to render items in 3D, similar to an Item Frame.

Previously, a new `EntityItem` was instantiated for every render call, causing excessive object creation.

This patch introduces a cache: the `EntityItem` is now stored in the Drawer’s `ExtendedData` map and reused for subsequent renders.

**Measured impact:**

- The number of `EntityItem` allocations measured by profiling with `visualvm` is reduced by a factor of 100.
- This significantly relieves garbage collector pressure during rendering.

**Relevant config:**

`StorageDrawers.cfg`:
 
```toml
    S:itemRenderType=fancy
```