### PR TITLE
Prevent some crashes when grabbing items from drawers

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -376,12 +376,14 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
                     if (locked) {
                         int slot = getDrawerSlot(side, hitX, hitY, hitZ);
                         IDrawer drawer = tileDrawers.getDrawer(slot);
-                        ItemStack stack = drawer.getStoredItemPrototype();
-                        int count = drawer.getStoredItemCount();
+                        if (drawer != null) {
+                            ItemStack stack = drawer.getStoredItemPrototype();
+                            int count = drawer.getStoredItemCount();
 
-                        if (stack != null && count == 0) {
-                            drawer.setStoredItemRedir(null, 0);
-                            return true;
+                            if (stack != null && count == 0) {
+                                drawer.setStoredItemRedir(null, 0);
+                                return true;
+                            }
                         }
                     }
                     tileDrawers.setLocked(LockAttribute.LOCK_POPULATED, !locked);
@@ -424,10 +426,12 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
 
         int slot = getDrawerSlot(side, hitX, hitY, hitZ);
         IDrawer drawer = tileDrawers.getDrawer(slot);
-        ItemStack currentStack = drawer.getStoredItemPrototype();
+        if (drawer != null) {
+            ItemStack currentStack = drawer.getStoredItemPrototype();
 
-        int countAdded = tileDrawers.interactPutItemsIntoSlot(slot, player);
-        if (countAdded > 0 && currentStack != null) world.markBlockForUpdate(x, y, z);
+            int countAdded = tileDrawers.interactPutItemsIntoSlot(slot, player);
+            if (countAdded > 0 && currentStack != null) world.markBlockForUpdate(x, y, z);
+        }
 
         return true;
     }
@@ -504,6 +508,7 @@ public class BlockDrawers extends BlockContainer implements IExtendedBlockClickH
 
         int slot = getDrawerSlot(side, hitX, hitY, hitZ);
         IDrawer drawer = tileDrawers.getDrawer(slot);
+        if (drawer == null) return;
 
         final ItemStack item;
         // if invertSHift is true this will happen when the player is not shifting

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -38,6 +38,8 @@ import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
+import javax.annotation.Nullable;
+
 public abstract class TileEntityDrawers extends BaseTileEntity implements IDrawerGroupInteractive, ISidedInventory,
         IUpgradeProvider, ILockable, ISealable, IProtectable, IDowngradable {
 
@@ -857,6 +859,7 @@ public abstract class TileEntityDrawers extends BaseTileEntity implements IDrawe
     }
 
     @Override
+    @Nullable
     public IDrawer getDrawer(int slot) {
         if (slot < 0 || slot >= drawers.length) return null;
 


### PR DESCRIPTION
[Received](https://discord.com/channels/181078474394566657/234936569360809996/1421027625177972747) some crash reports in Discord that occurred when inserting/removing items from a drawer wall with a controller. I cannot reproduce these, but `TileEntityDrawers#getDrawer` can return null, so make sure callers of the have the appropriate null check.

[crashlog](https://github.com/user-attachments/files/22557810/message.txt)

```
java.lang.NullPointerException
    at com.jaquadro.minecraft.storagedrawers.block.BlockDrawers.onBlockActivated(BlockDrawers.java:425)
    at net.minecraft.client.multiplayer.PlayerControllerMP.onPlayerRightClick(PlayerControllerMP.java:326)
```
