### PR TITLE
Fix conveyors dropping items from creative drawers

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
@@ -43,6 +43,10 @@ public interface IDrawer {
      */
     IDrawer setStoredItemRedir(ItemStack itemPrototype, int amount);
 
+    default boolean isVendingUnlimited() {
+        return false;
+    }
+
     /**
      * Gets the number of items stored in this drawer.
      */

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -28,6 +28,7 @@ import com.gtnewhorizon.gtnhlib.item.AbstractInventoryIterator;
 import com.gtnewhorizon.gtnhlib.item.ImmutableItemStack;
 import com.gtnewhorizon.gtnhlib.item.InventoryIterator;
 import com.gtnewhorizon.gtnhlib.item.SimpleItemIO;
+import com.gtnewhorizon.gtnhlib.util.ItemUtil;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.inventory.IDrawerInventory;
 import com.jaquadro.minecraft.storagedrawers.api.security.ISecurityProvider;
@@ -1044,6 +1045,10 @@ public abstract class TileEntityDrawers extends BaseTileEntity implements IDrawe
                     if (slot < 0 || slot >= drawers.length) return stack.getStackSize();
 
                     IDrawer drawer = drawers[slot];
+
+                    if (drawer.isVendingUnlimited()
+                            && ItemUtil.areStacksEqual(stack.toStackFast(), drawer.getStoredItemPrototype()))
+                        return 0;
 
                     ItemStack insertExample = stack.toStackFast();
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DrawerData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DrawerData.java
@@ -32,6 +32,11 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
     }
 
     @Override
+    public boolean isVendingUnlimited() {
+        return storageProvider.isVendingUnlimited(slot);
+    }
+
+    @Override
     public ItemStack getStoredItemPrototype() {
         if (protoStack == nullStack) return null;
 
@@ -77,7 +82,7 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
 
     @Override
     public int getStoredItemCount() {
-        if (protoStack != nullStack && storageProvider.isVendingUnlimited(slot)) return Integer.MAX_VALUE;
+        if (protoStack != nullStack && isVendingUnlimited()) return Integer.MAX_VALUE;
 
         return count;
     }
@@ -88,7 +93,7 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
     }
 
     public void setStoredItemCount(int amount, boolean mark, boolean clearOnEmpty) {
-        if (storageProvider.isVendingUnlimited(slot)) return;
+        if (isVendingUnlimited()) return;
 
         count = amount;
         if (count > getMaxCapacity()) count = getMaxCapacity();


### PR DESCRIPTION
Deletes all inserted stacks that match the drawer's contents when the drawer has a creative upgrade.