### PR TITLE
Add ability to break drawer in the front when it is empty

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/mixins/early/MixinPlayerControllerMP.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/mixins/early/MixinPlayerControllerMP.java
@@ -1,7 +1,9 @@
 package com.jaquadro.minecraft.storagedrawers.mixins.early;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.PlayerControllerMP;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MovingObjectPosition;
 
 import org.spongepowered.asm.mixin.Final;
@@ -13,6 +15,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
 import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers;
 import com.jaquadro.minecraft.storagedrawers.network.BlockClickMessage;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
@@ -36,8 +40,10 @@ public abstract class MixinPlayerControllerMP {
                     value = "INVOKE",
                     target = "Lnet/minecraft/block/Block;getPlayerRelativeBlockHardness(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/world/World;III)F"))
     private float storageDrawers$checkIfClickingDrawer(float originalHardness, int x, int y, int z, int clickedSide) {
-        final var thisTile = mc.theWorld.getTileEntity(x, y, z);
-        if (!(thisTile instanceof TileEntityDrawers drawer) || drawer.getDirection() != clickedSide) {
+        final TileEntity thisTile = mc.theWorld.getTileEntity(x, y, z);
+        final Block thisBlock = mc.theWorld.getBlock(x, y, z);
+        if (!(thisBlock instanceof BlockDrawers blockDrawer) || !(thisTile instanceof TileEntityDrawers drawer)
+                || drawer.getDirection() != clickedSide) {
             return originalHardness;
         }
 
@@ -45,6 +51,10 @@ public abstract class MixinPlayerControllerMP {
         float hitX = (float) (mop.hitVec.xCoord - mop.blockX);
         float hitY = (float) (mop.hitVec.yCoord - mop.blockY);
         float hitZ = (float) (mop.hitVec.zCoord - mop.blockZ);
+        IDrawer clickedDrawer = drawer.getDrawer(blockDrawer.getDrawerSlot(clickedSide, hitX, hitY, hitZ));
+        if (clickedDrawer == null || clickedDrawer.isEmpty()) {
+            return originalHardness;
+        }
         boolean invertShift = StorageDrawers.config.cache.invertShift;
         boolean isHolding = this.storageDrawers$isHoldingClick;
 


### PR DESCRIPTION
This PR adds the ability to break the drawer from the front when it is empty. For multi-slot drawers, it will be broken if you are pointing to a drawer slot that is empty, but extract it if you are pointing to one that is not empty. 

It does duplicate the calculation of checking the drawer slot, but I thought that would be better than if the `BlockClickMessage` was interfered with by having something specific to drawers.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24290.