### PR TITLE
Move Module Loader to Pre-intialization

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/StorageDrawers.java
@@ -95,6 +95,7 @@ public class StorageDrawers {
 
         blocks.init();
         items.init();
+        IntegrationRegistry.instance().init();
     }
 
     @Mod.EventHandler
@@ -104,8 +105,6 @@ public class StorageDrawers {
         NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
         FMLCommonHandler.instance().bus().register(instance);
         MinecraftForge.EVENT_BUS.register(new ForgeEventHandler());
-
-        IntegrationRegistry.instance().init();
     }
 
     @Mod.EventHandler


### PR DESCRIPTION
The storage drawer packs are also loaded in preinit, so previously they would get loaded before chisel, and thus would not have chisel recipes
Tested in daily 534
<img width="335" height="588" alt="image" src="https://github.com/user-attachments/assets/824786d1-de63-4731-bb4c-a31ffe66f9b4" />

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24441