### PR TITLE
Reduced drawer controller overhead

### DIFF
--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
@@ -1,15 +1,35 @@
 package com.jaquadro.minecraft.storagedrawers.api.storage;
 
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 public interface IDrawer {
+
+    List<ItemStack> getOreDictMatches();
+
+    TileEntityController getController();
+
+    int getControllerDrawerSlot();
+
+    /**
+     * Provide reference to controller
+     */
+    void setTileEntityController(TileEntityController controller, int controllerDrawerSlot);
+
+    /**
+     * Delete reference to controller
+     */
+    void clearTileEntityController();
 
     /**
      * Gets an ItemStack of size 1 representing the type, metadata, and tags of the stored items. The returned ItemStack

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
@@ -1,8 +1,110 @@
 package com.jaquadro.minecraft.storagedrawers.api.storage;
 
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
 import com.jaquadro.minecraft.storagedrawers.api.inventory.IDrawerInventory;
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockCoord;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 
 public interface IDrawerGroup {
+
+    /**
+     * Search for a neighbour that has a controller coord for full controller update when this drawer group when a
+     * drawer/slave is placed.
+     */
+    default void refreshController(World world, int x, int y, int z) {
+
+        BlockCoord start = new BlockCoord(x, y, z);
+
+        Queue<BlockCoord> searchCoordQueue = new LinkedList<BlockCoord>();
+        Set<BlockCoord> visited = new HashSet<BlockCoord>();
+
+        searchCoordQueue.add(start);
+        visited.add(start);
+
+        BlockCoord discoveredController = null;
+
+        // Test direct surrounding neighbors (or multiple INetworked non drawer blocks (trims)) for a valid drawer Coord
+        while (!searchCoordQueue.isEmpty()) {
+
+            BlockCoord current = searchCoordQueue.poll();
+
+            BlockCoord[] neighbors = new BlockCoord[] { new BlockCoord(current.x() + 1, current.y(), current.z()),
+                    new BlockCoord(current.x() - 1, current.y(), current.z()),
+                    new BlockCoord(current.x(), current.y(), current.z() + 1),
+                    new BlockCoord(current.x(), current.y(), current.z() - 1),
+                    new BlockCoord(current.x(), current.y() + 1, current.z()),
+                    new BlockCoord(current.x(), current.y() - 1, current.z()), };
+
+            for (BlockCoord n : neighbors) {
+
+                // Must not have been visited before
+                if (visited.contains(n)) continue;
+                visited.add(n);
+
+                // Must be an INetworked (Drawer, Controller, Slave, Trim)
+                Block block = world.getBlock(n.x(), n.y(), n.z());
+                if (!(block instanceof INetworked)) continue;
+
+                // Drawer or slave
+                TileEntity te = world.getTileEntity(n.x(), n.y(), n.z());
+                if (te instanceof IDrawerGroup) {
+
+                    IDrawerGroup drawer = (IDrawerGroup) te;
+
+                    if (drawer.getControllerCoord() != null) {
+                        discoveredController = drawer.getControllerCoord();
+                    }
+                }
+
+                // Only trims added to queue
+                else {
+                    searchCoordQueue.add(n);
+                }
+            }
+            if (discoveredController != null) {
+                break;
+            }
+        }
+
+        // No Controller found
+        if (discoveredController == null) return;
+
+        TileEntity controllerTe = world
+                .getTileEntity(discoveredController.x(), discoveredController.y(), discoveredController.z());
+
+        if (controllerTe instanceof TileEntityController) {
+            ((TileEntityController) controllerTe).scheduleFullUpdate();
+        }
+    }
+
+    /**
+     * Schedule controller update if IDrawerGroup was linked when block broken.
+     */
+    void controllerFullUpdate();
+
+    /**
+     * Gets controller coordinate for this group.
+     */
+    BlockCoord getControllerCoord();
+
+    /**
+     * Sets controller coordinate for this group.
+     */
+    void setControllerCoord(int sourceControllerX, int sourceControllerY, int sourceControllrZ);
+
+    /**
+     * Clear Variables used for controller access if it is linked to that controllers coords
+     */
+    void clearControllerVariables(int sourceControllerX, int sourceControllerY, int sourceControllerZ,
+            boolean nullController);
 
     /**
      * Gets the number of drawers contained within this group.

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockController.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
@@ -83,6 +84,7 @@ public class BlockController extends BlockContainer implements INetworked {
         if (tile.getDirection() > 1) return;
 
         int quadrant = MathHelper.floor_double((entity.rotationYaw * 4f / 360f) + .5) & 3;
+
         switch (quadrant) {
             case 0:
                 tile.setDirection(2);
@@ -113,46 +115,100 @@ public class BlockController extends BlockContainer implements INetworked {
         TileEntityController te = getTileEntity(world, x, y, z);
         if (te == null) return;
 
-        te.updateCache();
+        te.fullDrawerUpdate();
+    }
+
+    @Override
+    public void onBlockPreDestroy(World worldIn, int x, int y, int z, int meta) {
+        if (worldIn.isRemote) return;
+
+        TileEntityController te = getTileEntity(worldIn, x, y, z);
+        if (te == null) return;
+
+        te.syncClient();
+        te.clearStorage(true);
     }
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
             float hitY, float hitZ) {
+
         TileEntityController te = getTileEntitySafe(world, x, y, z);
-        ItemStack item = player.inventory.getCurrentItem();
+        ItemStack heldItem = player.inventory.getCurrentItem();
 
-        if (item != null && item.getItem() != null) {
-            if (item.getItem() == ModItems.shroudKey) {
-                if (!world.isRemote) te.toggleShroud(player.getGameProfile());
-                return true;
-            } else if (item.getItem() == ModItems.upgradeLock) {
-                if (!world.isRemote) te.toggleLock(
-                        EnumSet.allOf(LockAttribute.class),
-                        LockAttribute.LOCK_POPULATED,
-                        player.getGameProfile());
-                return true;
-            } else if (item.getItem() == ModItems.personalKey) {
-                if (!world.isRemote) {
-                    String securityKey = ((ItemPersonalKey) item.getItem())
-                            .getSecurityProviderKey(item.getItemDamage());
-                    ISecurityProvider provider = StorageDrawers.securityRegistry.getProvider(securityKey);
+        boolean isSneaking = player.isSneaking();
 
-                    te.toggleProtection(player.getGameProfile(), provider);
+        if (te.getDirection() != side) {
+
+            if (!isSneaking) {
+
+                if (heldItem == null || heldItem.getItem() == null) {
+                    if (!world.isRemote) {
+                        player.addChatMessage(
+                                new ChatComponentText(
+                                        "Extracting " + ((te.getExtractionItem() == null) ? "Nothing"
+                                                : te.getExtractionItem().getDisplayName())));
+                    }
+                } else {
+                    if (!world.isRemote) {
+                        if (te.getExtractionItem() == null) te.setExtractionItem(heldItem);
+                        player.addChatMessage(
+                                new ChatComponentText(
+                                        "Extracting " + ((te.getExtractionItem() == null) ? "Nothing"
+                                                : te.getExtractionItem().getDisplayName())));
+                    }
                 }
-
                 return true;
-            } else if (item.getItem() == ModItems.quantifyKey) {
-                if (!world.isRemote) te.toggleQuantify(player.getGameProfile());
+            } else if (heldItem == null || heldItem.getItem() == null) {
+                if (!world.isRemote) {
+                    te.setExtractionItem(null);
+                    player.addChatMessage(new ChatComponentText("Extracting Nothing"));
+                }
                 return true;
             }
+            return false;
         }
 
-        if (te.getDirection() != side) return false;
+        else {
 
-        if (!world.isRemote) te.interactPutItemsIntoInventory(player);
+            if (heldItem != null && heldItem.getItem() != null) {
+                if (heldItem.getItem() == ModItems.shroudKey) {
+                    if (!world.isRemote) te.toggleShroud(player.getGameProfile());
+                    return true;
+                } else if (heldItem.getItem() == ModItems.upgradeLock) {
+                    if (!world.isRemote) te.toggleLock(
+                            EnumSet.allOf(LockAttribute.class),
+                            LockAttribute.LOCK_POPULATED,
+                            player.getGameProfile());
+                    return true;
+                } else if (heldItem.getItem() == ModItems.personalKey) {
+                    if (!world.isRemote) {
+                        String securityKey = ((ItemPersonalKey) heldItem.getItem())
+                                .getSecurityProviderKey(heldItem.getItemDamage());
+                        ISecurityProvider provider = StorageDrawers.securityRegistry.getProvider(securityKey);
 
-        return true;
+                        te.toggleProtection(player.getGameProfile(), provider);
+                    }
+
+                    return true;
+                } else if (heldItem.getItem() == ModItems.quantifyKey) {
+                    if (!world.isRemote) te.toggleQuantify(player.getGameProfile());
+                    return true;
+                }
+            } else if (isSneaking) {
+                if (!world.isRemote) {
+                    te.toggleSync();
+                    if (te.getClientAutoSync()) {
+                        player.addChatMessage(new ChatComponentText("Client Auto Sync Enabled"));
+                    } else player.addChatMessage(new ChatComponentText("Client Auto Sync Disabled"));
+                }
+            }
+            if (!world.isRemote) {
+                te.interactPutItemsIntoInventory(player);
+            }
+            return true;
+
+        }
     }
 
     @Override
@@ -184,7 +240,7 @@ public class BlockController extends BlockContainer implements INetworked {
         TileEntityController te = getTileEntity(world, x, y, z);
         if (te == null) return;
 
-        te.updateCache();
+        te.updateOnTick();
 
         world.scheduleBlockUpdate(x, y, z, this, this.tickRate(world));
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockDrawers.java
@@ -325,8 +325,29 @@ public class BlockDrawers extends BlockContainer implements INetworked {
     }
 
     @Override
+    public void onPostBlockPlaced(World world, int x, int y, int z, int meta) {
+        if (world.isRemote) return;
+
+        TileEntityDrawers te = getTileEntitySafe(world, x, y, z);
+        if (te == null) return;
+
+        te.refreshController(world, x, y, z);
+    }
+
+    @Override
+    public void onBlockPreDestroy(World worldIn, int x, int y, int z, int meta) {
+        if (worldIn.isRemote) return;
+
+        TileEntityDrawers te = getTileEntitySafe(worldIn, x, y, z);
+        if (te == null) return;
+
+        te.controllerFullUpdate();
+    }
+
+    @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
             float hitY, float hitZ) {
+
         if (world.isRemote && Minecraft.getSystemTime() == ignoreEventTime) {
             ignoreEventTime = 0;
             return false;
@@ -391,13 +412,9 @@ public class BlockDrawers extends BlockContainer implements INetworked {
         if (tileDrawers.isSealed()) return false;
 
         int slot = getDrawerSlot(side, hitX, hitY, hitZ);
-        IDrawer drawer = tileDrawers.getDrawer(slot);
-        if (drawer != null) {
-            ItemStack currentStack = drawer.getStoredItemPrototype();
 
-            int countAdded = tileDrawers.interactPutItemsIntoSlot(slot, player);
-            if (countAdded > 0 && currentStack != null) world.markBlockForUpdate(x, y, z);
-        }
+        if (!world.isRemote) tileDrawers.interactPutItemsIntoSlot(slot, player);
+
         return true;
     }
 
@@ -612,7 +629,7 @@ public class BlockDrawers extends BlockContainer implements INetworked {
      * Drops stacks with an "illegal" size that will contain all the items in one stack. The downside of this method is
      * that if the ItemStack is still on the ground when the chunk is saved (stopping game, or going away). It will not
      * save the size of the ItemStack correctly since the size is stored as a byte (max 255)
-     * {@link net.minecraft.item.ItemStack#writeToNBT(NBTTagCompound)}, ITEMS WILL BE LOST !!
+     * {@link ItemStack#writeToNBT(NBTTagCompound)}, ITEMS WILL BE LOST !!
      */
     private static void dropMergedStacks(TileEntityDrawers tile, World world, int x, int y, int z) {
         for (int i = 0; i < tile.getDrawerCount(); i++) {
@@ -632,7 +649,7 @@ public class BlockDrawers extends BlockContainer implements INetworked {
      * Drops an ItemStack with an "illegal" size that will contain all the items in one stack. The downside of this
      * method is that if the ItemStack is still on the ground when the chunk is saved (stopping game, or going away). It
      * will not save the size of the ItemStack correctly since the size is stored as a byte (max 255)
-     * {@link net.minecraft.item.ItemStack#writeToNBT(NBTTagCompound)}, ITEMS WILL BE LOST !!
+     * {@link ItemStack#writeToNBT(NBTTagCompound)}, ITEMS WILL BE LOST !!
      */
     private static void dropBigStackInWorld(World world, int x, int y, int z, ItemStack stack) {
         if (stack == null || stack.stackSize <= 0) return;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/BlockSlave.java
@@ -4,7 +4,10 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -51,8 +54,61 @@ public class BlockSlave extends BlockContainer implements INetworked {
         return new TileEntitySlave();
     }
 
-    public void bindController(World world, int x, int y, int z) {
+    @Override
+    public void onPostBlockPlaced(World world, int x, int y, int z, int meta) {
+        if (world.isRemote) return;
+
         TileEntitySlave te = getTileEntitySafe(world, x, y, z);
+        if (te == null) return;
+
+        te.refreshController(world, x, y, z);
+    }
+
+    @Override
+    public void onBlockPreDestroy(World worldIn, int x, int y, int z, int meta) {
+        if (worldIn.isRemote) return;
+
+        TileEntitySlave te = getTileEntitySafe(worldIn, x, y, z);
+        if (te == null) return;
+
+        te.controllerFullUpdate();
+    }
+
+    @Override
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
+            float hitY, float hitZ) {
+
+        TileEntitySlave te = getTileEntitySafe(world, x, y, z);
+        boolean isSneaking = player.isSneaking();
+        ItemStack heldItem = player.inventory.getCurrentItem();
+
+        if (!isSneaking) {
+
+            if (heldItem == null || heldItem.getItem() == null) {
+                if (!world.isRemote) {
+                    player.addChatMessage(
+                            new ChatComponentText(
+                                    "Extracting " + ((te.getExtractionItem() == null) ? "Nothing"
+                                            : te.getExtractionItem().getDisplayName())));
+                }
+            } else {
+                if (!world.isRemote) {
+                    if (te.getExtractionItem() == null) te.setExtractionItem(heldItem);
+                    player.addChatMessage(
+                            new ChatComponentText(
+                                    "Extracting " + ((te.getExtractionItem() == null) ? "Nothing"
+                                            : te.getExtractionItem().getDisplayName())));
+                }
+            }
+            return true;
+        } else if (heldItem == null || heldItem.getItem() == null) {
+            if (!world.isRemote) {
+                te.setExtractionItem(null);
+                player.addChatMessage(new ChatComponentText("Extracting Nothing"));
+            }
+            return true;
+        }
+        return false;
     }
 
     public TileEntitySlave getTileEntity(IBlockAccess blockAccess, int x, int y, int z) {
@@ -65,7 +121,6 @@ public class BlockSlave extends BlockContainer implements INetworked {
         if (tile == null) {
             tile = createNewTileEntity(world, world.getBlockMetadata(x, y, z));
             world.setTileEntity(x, y, z, tile);
-            tile.ensureInitialized();
         }
 
         return tile;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockCoord.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/BlockCoord.java
@@ -3,11 +3,11 @@ package com.jaquadro.minecraft.storagedrawers.block.tile;
 /**
  * Created by Justin on 4/25/2015.
  */
-class BlockCoord {
+public class BlockCoord {
 
-    private int x;
-    private int y;
-    private int z;
+    private final int x;
+    private final int y;
+    private final int z;
 
     public BlockCoord(int x, int y, int z) {
         this.x = x;

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityController.java
@@ -1,8 +1,6 @@
 package com.jaquadro.minecraft.storagedrawers.block.tile;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,6 +8,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -24,6 +23,9 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.Constants;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.inventory.IDrawerInventory;
@@ -41,113 +43,82 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.IShroudable;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.IVoidable;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
-import com.jaquadro.minecraft.storagedrawers.block.BlockSlave;
 import com.jaquadro.minecraft.storagedrawers.security.SecurityManager;
-import com.jaquadro.minecraft.storagedrawers.util.ItemMetaListRegistry;
+import com.jaquadro.minecraft.storagedrawers.util.ItemHashMap;
+import com.jaquadro.minecraft.storagedrawers.util.SlotRecord;
 import com.mojang.authlib.GameProfile;
 
 public class TileEntityController extends TileEntity
         implements IDrawerGroup, IPriorityGroup, ISmartGroup, ISidedInventory {
 
-    private static final int PRI_VOID = 0;
-    private static final int PRI_LOCKED = 1;
-    private static final int PRI_NORMAL = 2;
-    private static final int PRI_EMPTY = 3;
-    private static final int PRI_LOCKED_EMPTY = 4;
-    private static final int PRI_DISABLED = 5;
-
-    private static final int DEPTH_LIMIT = 12;
-    private static final int[] emptySlots = new int[0];
-
-    private static class StorageRecord {
-
-        public IDrawerGroup storage;
-        public boolean mark;
-        public int invStorageSize;
-        public int drawerStorageSize;
-        public int distance = Integer.MAX_VALUE;
-
-        public void clear() {
-            storage = null;
-            mark = false;
-            invStorageSize = 0;
-            drawerStorageSize = 0;
-            distance = Integer.MAX_VALUE;
-        }
+    /**
+     * Each controller tick one of 3 updates can occur. FULL is queued when placing/loading controller block or removing
+     * a drawer from network. PRIORITY when removeing/adding new items or adding upgrade to a drawer. Priority included
+     * in FULL updates. NONE when no update needed (default state when no changes made since last update)
+     */
+    enum controllerUpdateType {
+        NONE,
+        PRIORITY,
+        FULL
     }
 
-    private static class SlotRecord {
-
-        public BlockCoord coord;
-        public int slot;
-
-        public int index;
-        public int priority;
-
-        public SlotRecord(BlockCoord coord, int slot) {
-            this.coord = coord;
-            this.slot = slot;
-        }
+    /**
+     * 6 proirity states a drawer slot can have as defined in getSlotPriority().
+     */
+    private enum priorityState {
+        PRI_VOID,
+        PRI_LOCKED,
+        PRI_NORMAL,
+        PRI_EMPTY,
+        PRI_LOCKED_EMPTY,
+        PRI_DISABLED
     }
 
-    private Comparator<SlotRecord> slotRecordComparator = new Comparator<SlotRecord>() {
+    /** Full update always needed when entity first loaded */
+    private controllerUpdateType nextUpdate = controllerUpdateType.FULL;
 
-        @Override
-        public int compare(SlotRecord o1, SlotRecord o2) {
-            return o1.priority - o2.priority;
-        }
-    };
+    /** 0 = insertion 1 = extraction used for IInvenotry interfacing blocks */
+    private final int[] virtualSlots = new int[] { 0, 1 };
+    private final int[] emptySlots = new int[] { 0 };
 
-    private int getSlotPriority(SlotRecord record, boolean invBased) {
-        IDrawerGroup group = getGroupForCoord(record.coord);
-        if (group == null) {
-            return PRI_DISABLED;
-        }
+    /** Item that controller Entity can extract with IInventory interface (Vanilla hoppers and Pipes) */
+    private ItemStack IInventoryExtract;
 
-        int drawerSlot = (invBased) ? group.getDrawerInventory().getDrawerSlot(record.slot) : record.slot;
-        if (!group.isDrawerEnabled(drawerSlot)) {
-            return PRI_DISABLED;
-        }
+    /** IDrawerGroup objects in network (drawers, controllers, slaves) are found here */
+    private final Map<BlockCoord, IDrawerGroup> storage = new HashMap<BlockCoord, IDrawerGroup>();
 
-        IDrawer drawer = group.getDrawer(drawerSlot);
-        if (drawer.isEmpty()) {
-            if ((drawer instanceof ILockable && ((ILockable) drawer).isLocked(LockAttribute.LOCK_EMPTY))
-                    || (group instanceof ILockable && ((ILockable) group).isLocked(LockAttribute.LOCK_EMPTY))) {
-                return PRI_LOCKED_EMPTY;
-            } else return PRI_EMPTY;
-        }
+    /** SlotRecords with coordinate referencing storage along with access indexes */
+    private final List<SlotRecord> drawerSlotList = new ArrayList<SlotRecord>();
 
-        if ((drawer instanceof IVoidable && ((IVoidable) drawer).isVoid())
-                || (group instanceof IVoidable && ((IVoidable) group).isVoid())) {
-            return PRI_VOID;
-        }
+    /** Containers for ordering drawerSlots during priority update */
+    private final List<List<Integer>> drawerSlotPriorityBins = new ArrayList<>();
 
-        if ((drawer instanceof ILockable && ((ILockable) drawer).isLocked(LockAttribute.LOCK_POPULATED))
-                || (group instanceof ILockable && ((ILockable) group).isLocked(LockAttribute.LOCK_POPULATED))) {
-            return PRI_LOCKED;
-        }
-
-        return PRI_NORMAL;
-    }
-
-    private Queue<BlockCoord> searchQueue = new LinkedList<BlockCoord>();
-    private Set<BlockCoord> searchDiscovered = new HashSet<BlockCoord>();
-
-    private Map<BlockCoord, StorageRecord> storage = new HashMap<BlockCoord, StorageRecord>();
-    private List<SlotRecord> invSlotList = new ArrayList<SlotRecord>();
-    private List<SlotRecord> drawerSlotList = new ArrayList<SlotRecord>();
-
-    private ItemMetaListRegistry<SlotRecord> invPrimaryLookup = new ItemMetaListRegistry<SlotRecord>();
-    private ItemMetaListRegistry<SlotRecord> drawerPrimaryLookup = new ItemMetaListRegistry<SlotRecord>();
-
-    private int[] inventorySlots = new int[0];
+    /** drawerSlotList indices in Priority order */
     private int[] drawerSlots = new int[0];
-    private int[] autoSides = new int[] { 0, 1, 2, 3, 4, 5 };
-    private int direction;
 
-    private int drawerSize = 0;
-    private int range;
-    private int maxDrawers;
+    /** int[] drawerSlots Index of first empty slot since last priority update or when setting slot to null */
+    private int emptyDrawerSlot = 0;
+
+    /** Lookup a drawerSlotList for a given itemstack request (including oredictionary if no direct match) */
+    private final ItemHashMap drawerPrimaryLookup = new ItemHashMap();
+
+    /**
+     * to prevent multiple controllers they are cleared when encountered during full update either directly or from
+     * another drawer linked to a different controller. This variable prevents multiple clears of the same controller
+     */
+    private final Set<BlockCoord> clearedControllers = new HashSet<BlockCoord>();
+
+    /**
+     * if disableAutoSync is true drawers that need syncing to client will go into syncSet and sync only when loading,
+     * doing inventory dump, toggling autosync or breaking controller
+     */
+    private boolean enableClientAutoSync = true;
+    private final Set<BlockCoord> syncSet = new HashSet<BlockCoord>();
+
+    private int direction;
+    private final int range;
+    private final int maxDrawers;
+
     private int drawersCount;
 
     private long lastClickTime;
@@ -156,10 +127,13 @@ public class TileEntityController extends TileEntity
     private String customName;
 
     public TileEntityController() {
-        invSlotList.add(new SlotRecord(null, 0));
-        inventorySlots = new int[] { 0 };
+
         range = StorageDrawers.config.getControllerRange();
         maxDrawers = StorageDrawers.config.getControllerMaxDrawers();
+
+        for (int i = 0; i < priorityState.values().length; i++) {
+            drawerSlotPriorityBins.add(new ArrayList<>());
+        }
     }
 
     public int getDirection() {
@@ -170,8 +144,7 @@ public class TileEntityController extends TileEntity
         this.direction = direction % 6;
     }
 
-    public int interactPutItemsIntoInventory(EntityPlayer player) {
-        if (inventorySlots.length == 0) updateCache();
+    public void interactPutItemsIntoInventory(EntityPlayer player) {
 
         boolean dumpInventory = worldObj.getTotalWorldTime() - lastClickTime < 10
                 && player.getPersistentID().equals(lastClickUUID);
@@ -193,19 +166,20 @@ public class TileEntityController extends TileEntity
                 }
             }
 
+            syncClient();
+
             if (count > 0) StorageDrawers.proxy.updatePlayerInventory(player);
         }
 
         lastClickTime = worldObj.getTotalWorldTime();
         lastClickUUID = player.getPersistentID();
-
-        return count;
     }
 
-    private int insertItems(ItemStack stack, GameProfile profile) {
+    private int insertItems(@NotNull ItemStack stack, GameProfile profile) {
         int itemsLeft = stack.stackSize;
 
         for (int slot : enumerateDrawersForInsertion(stack, false)) {
+
             IDrawerGroup group = getGroupForDrawerSlot(slot);
             if (group instanceof IProtectable) {
                 if (!SecurityManager.hasAccess(profile, (IProtectable) group)) continue;
@@ -215,7 +189,7 @@ public class TileEntityController extends TileEntity
             ItemStack itemProto = drawer.getStoredItemPrototype();
             if (itemProto == null) break;
 
-            itemsLeft = insertItemsIntoDrawer(drawer, itemsLeft);
+            itemsLeft = insertItemsIntoDrawer(drawer, itemsLeft, false);
 
             if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) itemsLeft = 0;
             if (itemsLeft == 0) break;
@@ -227,7 +201,8 @@ public class TileEntityController extends TileEntity
         return count;
     }
 
-    private int insertItemsIntoDrawer(IDrawer drawer, int itemCount) {
+    public int insertItemsIntoDrawer(@NotNull IDrawer drawer, int itemCount, boolean testOnly) {
+
         int capacity = drawer.getMaxCapacity();
         int storedItems = drawer.getStoredItemCount();
 
@@ -240,6 +215,9 @@ public class TileEntityController extends TileEntity
         if (storableItems == 0) return itemCount;
 
         int remainder = Math.max(itemCount - storableItems, 0);
+
+        if (testOnly) return remainder;
+
         storedItems += Math.min(itemCount, storableItems);
         drawer.setStoredItemCount(storedItems);
 
@@ -250,11 +228,11 @@ public class TileEntityController extends TileEntity
         IProtectable template = null;
         UUID state = null;
 
-        for (StorageRecord record : storage.values()) {
-            if (record.storage == null) continue;
+        for (IDrawerGroup drawerGroup : storage.values()) {
+            if (drawerGroup == null) continue;
 
-            if (record.storage instanceof IProtectable) {
-                IProtectable protectable = (IProtectable) record.storage;
+            if (drawerGroup instanceof IProtectable) {
+                IProtectable protectable = (IProtectable) drawerGroup;
                 if (!SecurityManager.hasOwnership(profile, protectable)) continue;
 
                 if (template == null) {
@@ -277,17 +255,17 @@ public class TileEntityController extends TileEntity
         IShroudable template = null;
         boolean state = false;
 
-        for (StorageRecord record : storage.values()) {
-            if (record.storage == null) continue;
+        for (IDrawerGroup drawerGroup : storage.values()) {
+            if (drawerGroup == null) continue;
 
-            if (record.storage instanceof IProtectable) {
-                if (!SecurityManager.hasAccess(profile, (IProtectable) record.storage)) continue;
+            if (drawerGroup instanceof IProtectable) {
+                if (!SecurityManager.hasAccess(profile, (IProtectable) drawerGroup)) continue;
             }
 
-            for (int i = 0, n = record.storage.getDrawerCount(); i < n; i++) {
-                if (!record.storage.isDrawerEnabled(i)) continue;
+            for (int i = 0, n = drawerGroup.getDrawerCount(); i < n; i++) {
+                if (!drawerGroup.isDrawerEnabled(i)) continue;
 
-                IDrawer drawer = record.storage.getDrawer(i);
+                IDrawer drawer = drawerGroup.getDrawer(i);
                 if (!(drawer instanceof IShroudable)) continue;
 
                 IShroudable shroudableStorage = (IShroudable) drawer;
@@ -305,17 +283,17 @@ public class TileEntityController extends TileEntity
         IQuantifiable template = null;
         boolean state = false;
 
-        for (StorageRecord record : storage.values()) {
-            if (record.storage == null) continue;
+        for (IDrawerGroup drawerGroup : storage.values()) {
+            if (drawerGroup == null) continue;
 
-            if (record.storage instanceof IProtectable) {
-                if (!SecurityManager.hasAccess(profile, (IProtectable) record.storage)) continue;
+            if (drawerGroup instanceof IProtectable) {
+                if (!SecurityManager.hasAccess(profile, (IProtectable) drawerGroup)) continue;
             }
 
-            for (int i = 0, n = record.storage.getDrawerCount(); i < n; i++) {
-                if (!record.storage.isDrawerEnabled(i)) continue;
+            for (int i = 0, n = drawerGroup.getDrawerCount(); i < n; i++) {
+                if (!drawerGroup.isDrawerEnabled(i)) continue;
 
-                IDrawer drawer = record.storage.getDrawer(i);
+                IDrawer drawer = drawerGroup.getDrawer(i);
                 if (!(drawer instanceof IQuantifiable)) continue;
 
                 IQuantifiable quantifiableStorage = (IQuantifiable) drawer;
@@ -333,15 +311,15 @@ public class TileEntityController extends TileEntity
         ILockable template = null;
         boolean state = false;
 
-        for (StorageRecord record : storage.values()) {
-            if (record.storage == null) continue;
+        for (IDrawerGroup drawerGroup : storage.values()) {
+            if (drawerGroup == null) continue;
 
-            if (record.storage instanceof IProtectable) {
-                if (!SecurityManager.hasAccess(profile, (IProtectable) record.storage)) continue;
+            if (drawerGroup instanceof IProtectable) {
+                if (!SecurityManager.hasAccess(profile, (IProtectable) drawerGroup)) continue;
             }
 
-            if (record.storage instanceof ILockable) {
-                ILockable lockableStorage = (ILockable) record.storage;
+            if (drawerGroup instanceof ILockable) {
+                ILockable lockableStorage = (ILockable) drawerGroup;
                 if (template == null) {
                     template = lockableStorage;
                     state = !template.isLocked(key);
@@ -349,10 +327,10 @@ public class TileEntityController extends TileEntity
 
                 for (LockAttribute attr : attributes) lockableStorage.setLocked(attr, state);
             } else {
-                for (int i = 0, n = record.storage.getDrawerCount(); i < n; i++) {
-                    if (!record.storage.isDrawerEnabled(i)) continue;
+                for (int i = 0, n = drawerGroup.getDrawerCount(); i < n; i++) {
+                    if (!drawerGroup.isDrawerEnabled(i)) continue;
 
-                    IDrawer drawer = record.storage.getDrawer(i);
+                    IDrawer drawer = drawerGroup.getDrawer(i);
                     if (!(drawer instanceof IShroudable)) continue;
 
                     ILockable lockableStorage = (ILockable) drawer;
@@ -367,209 +345,241 @@ public class TileEntityController extends TileEntity
         }
     }
 
-    private void resetCache() {
-        storage.clear();
-        invSlotList.clear();
-        drawerSlotList.clear();
-        drawerSize = 0;
+    private void addSlotRecordMap(ItemHashMap lookup, SlotRecord record, @NotNull IDrawerGroup group) {
+
+        IDrawer drawer = group.getDrawer(record.slot);
+        if (drawer.isEmpty()) return;
+
+        ItemStack item = drawer.getStoredItemPrototype();
+        lookup.register(item.getItem(), item.getItemDamage(), record, drawer.getOreDictMatches());
     }
 
-    public boolean isValidSlave(BlockCoord coord) {
-        StorageRecord record = storage.get(coord);
-        if (record == null || !record.mark) return false;
-
-        return record.storage == null;
-    }
-
-    public void updateCache() {
-        int preCount = inventorySlots.length;
-
-        resetCache();
-
-        populateNodes(xCoord, yCoord, zCoord);
-
-        flattenLists();
-        inventorySlots = sortSlotRecords(invSlotList, true);
-        drawerSlots = sortSlotRecords(drawerSlotList, false);
-
-        rebuildPrimaryLookup(invPrimaryLookup, invSlotList, true);
-        rebuildPrimaryLookup(drawerPrimaryLookup, drawerSlotList, false);
-
-        if (preCount != inventorySlots.length && (preCount == 0 || inventorySlots.length == 0)) {
-            if (!worldObj.isRemote) markDirty();
-        }
-    }
-
-    private void indexSlotRecords(List<SlotRecord> records, boolean invBased) {
-        for (int i = 0, n = records.size(); i < n; i++) {
-            SlotRecord record = records.get(i);
-            if (record != null) {
-                record.index = i;
-                record.priority = getSlotPriority(record, invBased);
-            }
-        }
-    }
-
-    private int[] sortSlotRecords(List<SlotRecord> records, boolean invBased) {
-        indexSlotRecords(records, invBased);
-
-        List<SlotRecord> copied = new ArrayList<SlotRecord>(records);
-        Collections.sort(copied, slotRecordComparator);
-
-        int[] slotMap = new int[copied.size()];
-        for (int i = 0; i < slotMap.length; i++) slotMap[i] = copied.get(i).index;
-
-        return slotMap;
-    }
-
-    private void rebuildPrimaryLookup(ItemMetaListRegistry<SlotRecord> lookup, List<SlotRecord> records,
-            boolean invBased) {
-        lookup.clear();
-
-        for (SlotRecord record : records) {
-            IDrawerGroup group = getGroupForCoord(record.coord);
-            if (group == null) continue;
-
-            int drawerSlot = (invBased) ? group.getDrawerInventory().getDrawerSlot(record.slot) : record.slot;
-            if (!group.isDrawerEnabled(drawerSlot)) continue;
-
-            IDrawer drawer = group.getDrawer(drawerSlot);
-            if (drawer.isEmpty()) continue;
-
-            ItemStack item = drawer.getStoredItemPrototype();
-            lookup.register(item.getItem(), item.getItemDamage(), record);
-        }
-    }
-
-    private boolean containsNullEntries(List<SlotRecord> list) {
-        int nullCount = 0;
-        for (int i = 0, n = list.size(); i < n; i++) {
-            if (list.get(i) == null) nullCount++;
+    private priorityState getSlotPriority(@NotNull SlotRecord record) {
+        IDrawerGroup group = getGroupForCoord(record.coord);
+        if (group == null) {
+            return priorityState.PRI_DISABLED;
         }
 
-        return nullCount > 0;
+        int drawerSlot = record.slot;
+        if (!group.isDrawerEnabled(drawerSlot)) {
+            return priorityState.PRI_DISABLED;
+        }
+
+        IDrawer drawer = group.getDrawer(drawerSlot);
+        if (drawer.isEmpty()) {
+            if ((drawer instanceof ILockable && ((ILockable) drawer).isLocked(LockAttribute.LOCK_EMPTY))
+                    || (group instanceof ILockable && ((ILockable) group).isLocked(LockAttribute.LOCK_EMPTY))) {
+                return priorityState.PRI_LOCKED_EMPTY;
+            } else return priorityState.PRI_EMPTY;
+        }
+
+        if ((drawer instanceof IVoidable && ((IVoidable) drawer).isVoid())
+                || (group instanceof IVoidable && ((IVoidable) group).isVoid())) {
+            return priorityState.PRI_VOID;
+        }
+
+        if ((drawer instanceof ILockable && ((ILockable) drawer).isLocked(LockAttribute.LOCK_POPULATED))
+                || (group instanceof ILockable && ((ILockable) group).isLocked(LockAttribute.LOCK_POPULATED))) {
+            return priorityState.PRI_LOCKED;
+        }
+
+        return priorityState.PRI_NORMAL;
     }
 
-    private void flattenLists() {
-        if (containsNullEntries(invSlotList)) {
-            List<SlotRecord> newInvSlotList = new ArrayList<SlotRecord>();
+    public void drawerUpdatePriority() {
 
-            for (int i = 0, n = invSlotList.size(); i < n; i++) {
-                SlotRecord record = invSlotList.get(i);
-                if (record != null) newInvSlotList.add(record);
-            }
-
-            invSlotList = newInvSlotList;
-        }
-
-        if (containsNullEntries(drawerSlotList)) {
-            List<SlotRecord> newDrawerSlotList = new ArrayList<SlotRecord>();
-
-            for (int i = 0, n = drawerSlotList.size(); i < n; i++) {
-                SlotRecord record = drawerSlotList.get(i);
-                if (record != null) newDrawerSlotList.add(record);
-            }
-
-            drawerSlotList = newDrawerSlotList;
-        }
-    }
-
-    private void clearRecordInfo(BlockCoord coord, StorageRecord record) {
-        record.clear();
-
-        for (int i = 0; i < invSlotList.size(); i++) {
-            SlotRecord slotRecord = invSlotList.get(i);
-            if (slotRecord != null && coord.equals(slotRecord.coord)) invSlotList.set(i, null);
-        }
-
+        // drawerSlotPriorityBins already cleared at end of this function and only used here
         for (int i = 0; i < drawerSlotList.size(); i++) {
-            SlotRecord slotRecord = drawerSlotList.get(i);
-            if (slotRecord != null && coord.equals(slotRecord.coord)) drawerSlotList.set(i, null);
+            priorityState priority = getSlotPriority(drawerSlotList.get(i));
+            drawerSlotPriorityBins.get(priority.ordinal()).add(i);
+        }
+
+        // Resize drawerSlots if needed
+        int size = drawerSlotList.size();
+        if (size != drawerSlots.length) {
+            drawerSlots = new int[size];
+        }
+
+        emptyDrawerSlot = size;
+        int index = 0;
+        for (int i = 0; i < drawerSlotPriorityBins.size(); i++) {
+
+            for (int drawerSlotListSlot : drawerSlotPriorityBins.get(i)) {
+
+                if (i >= priorityState.PRI_EMPTY.ordinal() && emptyDrawerSlot == size) {
+                    emptyDrawerSlot = index;
+                }
+                drawerSlotList.get(drawerSlotListSlot).priorityIndex = index;
+                drawerSlots[index++] = drawerSlotListSlot;
+            }
+            drawerSlotPriorityBins.get(i).clear();
         }
     }
 
-    private void updateRecordInfo(BlockCoord coord, StorageRecord record, TileEntity te) {
-        if (te == null) {
-            if (record.storage != null) clearRecordInfo(coord, record);
+    public void DrawerSearchUpdateRecordInfo(TileEntity te) {
 
+        if (te == null) {
             return;
         }
 
         if (te instanceof TileEntityController) {
-            if (record.storage == null && record.invStorageSize > 0) return;
+            storage.put(new BlockCoord(te.xCoord, te.yCoord, te.zCoord), null);
+        }
 
-            if (record.storage != null) clearRecordInfo(coord, record);
+        else if (te instanceof TileEntitySlave) {
 
-            record.storage = null;
-            record.invStorageSize = 1;
+            storage.put(new BlockCoord(te.xCoord, te.yCoord, te.zCoord), null);
 
-            invSlotList.add(new SlotRecord(null, 0));
-        } else if (te instanceof TileEntitySlave) {
-            if (record.storage == null && record.invStorageSize == 0) {
-                if (((TileEntitySlave) te).getController() == this) return;
-            }
+            if (((TileEntitySlave) te).getController() != this)
+                ((TileEntitySlave) te).setControllerCoord(xCoord, yCoord, zCoord);
 
-            if (record.storage != null) clearRecordInfo(coord, record);
-
-            record.storage = null;
-            record.invStorageSize = 0;
-
-            ((TileEntitySlave) te).bindController(xCoord, yCoord, zCoord);
         } else if (te instanceof IDrawerGroup) {
-            IDrawerGroup group = (IDrawerGroup) te;
-            if (record.storage == group) return;
 
-            if (record.storage != null && record.storage != group) clearRecordInfo(coord, record);
+            IDrawerGroup group = (IDrawerGroup) te;
+            group.setControllerCoord(xCoord, yCoord, zCoord);
 
             IDrawerInventory inventory = group.getDrawerInventory();
             if (inventory == null) return;
 
-            record.storage = group;
-            record.invStorageSize = inventory.getSizeInventory();
-            record.drawerStorageSize = group.getDrawerCount();
+            storage.put(new BlockCoord(te.xCoord, te.yCoord, te.zCoord), group);
 
-            for (int i = 0, n = record.invStorageSize; i < n; i++) invSlotList.add(new SlotRecord(coord, i));
+            for (int i = 0, n = group.getDrawerCount(); i < n; i++) {
 
-            for (int i = 0, n = record.drawerStorageSize; i < n; i++) drawerSlotList.add(new SlotRecord(coord, i));
+                int size = drawerSlotList.size();
+                SlotRecord slotRecord = new SlotRecord(new BlockCoord(te.xCoord, te.yCoord, te.zCoord), i, size);
+                drawerSlotList.add(slotRecord);
 
-            drawerSize += record.drawerStorageSize;
-        } else {
-            if (record.storage != null) clearRecordInfo(coord, record);
+                IDrawer drawer = getDrawer(size);
+                drawer.setTileEntityController(this, size);
+
+                addSlotRecordMap(drawerPrimaryLookup, slotRecord, group);
+            }
         }
     }
 
-    private void populateNodes(int x, int y, int z) {
-        BlockCoord root = new BlockCoord(x, y, z);
+    /**
+     * Controller can be set such that any drawers registered do not sync as soon as an item is inserted/extracted
+     * (unless manually inserting) as these calls are expensive when inserting a large quantity of ItemStacks but result
+     * in displayed item count and texture not automatically updating. This function adds to the set of coordinates that
+     * need updating.
+     */
+    public void addClientSyncList(int xcoord, int ycoord, int zcoord) {
 
-        searchQueue.clear();
-        searchQueue.add(root);
+        BlockCoord teCoord = new BlockCoord(xcoord, ycoord, zcoord);
+        syncSet.add(teCoord);
+    }
 
-        searchDiscovered.clear();
-        searchDiscovered.add(root);
+    /** When drawer is interacted with sync with client */
+    public void syncClient() {
+
+        for (BlockCoord element : syncSet) {
+            getWorldObj().markBlockForUpdate(element.x(), element.y(), element.z());
+        }
+        syncSet.clear();
+    }
+
+    /** Set the controller not sync unless interacted with */
+    public void toggleSync() {
+        syncClient();
+        enableClientAutoSync = !enableClientAutoSync;
+    }
+
+    /** Get autosync configuration */
+    public boolean getClientAutoSync() {
+        return enableClientAutoSync;
+    }
+
+    /**
+     * Clear storage and drawer variables referring to this controller if nullControllerCoord is set (prevents markdirty
+     * being set upon loading)
+     */
+    public void clearStorage(boolean nullControllerCoord) {
+
+        for (IDrawerGroup drawer : storage.values()) {
+            if (drawer != null) {
+                drawer.clearControllerVariables(xCoord, yCoord, zCoord, nullControllerCoord);
+            }
+        }
+        storage.clear();
+    }
+
+    public void clearDrawerVariables(boolean nullControllerCoord) {
+
+        nextUpdate = controllerUpdateType.NONE;
 
         drawersCount = 0;
+        emptyDrawerSlot = 0;
+
+        clearStorage(nullControllerCoord);
+
+        drawerSlotList.clear();
+        drawerPrimaryLookup.clear();
+
+        syncSet.clear();
+    }
+
+    /** Fully erase and update the controller with all the drawers that it can access */
+    public void fullDrawerUpdate() {
+
+        clearDrawerVariables(false);
+
+        Set<BlockCoord> clearedControllers = new HashSet<BlockCoord>();
+        Set<BlockCoord> searchDiscovered = new HashSet<BlockCoord>();
+        Queue<BlockCoord> searchQueue = new LinkedList<BlockCoord>();
+
+        searchQueue.add(new BlockCoord(xCoord, yCoord, zCoord));
 
         while (!searchQueue.isEmpty()) {
-            BlockCoord coord = searchQueue.remove();
-            int depth = Math.max(Math.max(Math.abs(coord.x() - x), Math.abs(coord.y() - y)), Math.abs(coord.z() - z));
+
+            BlockCoord coord = searchQueue.poll();
+
+            int depth = Math.max(
+                    Math.max(Math.abs(coord.x() - xCoord), Math.abs(coord.y() - yCoord)),
+                    Math.abs(coord.z() - zCoord));
             if (depth > range) continue;
 
             Block block = worldObj.getBlock(coord.x(), coord.y(), coord.z());
+
             if (!(block instanceof INetworked)) continue;
 
-            StorageRecord record = storage.get(coord);
-            if (record == null) {
-                record = new StorageRecord();
-                storage.put(coord, record);
+            if (block instanceof BlockDrawers && ++drawersCount > maxDrawers) {
+                break;
             }
 
-            if (block instanceof BlockSlave) {
-                ((BlockSlave) block).getTileEntitySafe(worldObj, coord.x(), coord.y(), coord.z());
-            } else if (block instanceof BlockDrawers && ++drawersCount > maxDrawers) break;
+            // If any of the drawers are connected to another controller the controller variables should be cleared (one
+            // controller only)
+            TileEntity te = worldObj.getTileEntity(coord.x(), coord.y(), coord.z());
+            if (te instanceof IDrawerGroup) {
 
-            updateRecordInfo(coord, record, worldObj.getTileEntity(coord.x(), coord.y(), coord.z()));
-            record.mark = true;
-            record.distance = depth;
+                // Controllers
+                if (te instanceof TileEntityController && te != this
+                        && clearedControllers.add(new BlockCoord(coord.x(), coord.y(), coord.z()))) {
+                    ((TileEntityController) te).clearDrawerVariables(true);
+                }
+
+                // Drawers and slaves
+                else {
+
+                    BlockCoord connectedControllerCoord = ((IDrawerGroup) te).getControllerCoord();
+
+                    if (connectedControllerCoord != null && clearedControllers.add(
+                            new BlockCoord(
+                                    connectedControllerCoord.x(),
+                                    connectedControllerCoord.y(),
+                                    connectedControllerCoord.z()))) {
+
+                        TileEntity otherController = worldObj.getTileEntity(
+                                connectedControllerCoord.x(),
+                                connectedControllerCoord.y(),
+                                connectedControllerCoord.z());
+
+                        if (otherController instanceof TileEntityController && otherController != this) {
+                            ((TileEntityController) otherController).clearDrawerVariables(true);
+                        }
+                    }
+                    DrawerSearchUpdateRecordInfo(te);
+                }
+            }
 
             BlockCoord[] neighbors = new BlockCoord[] { new BlockCoord(coord.x() + 1, coord.y(), coord.z()),
                     new BlockCoord(coord.x() - 1, coord.y(), coord.z()),
@@ -579,24 +589,78 @@ public class TileEntityController extends TileEntity
                     new BlockCoord(coord.x(), coord.y() - 1, coord.z()), };
 
             for (BlockCoord n : neighbors) {
-                if (!searchDiscovered.contains(n)) {
+                if (searchDiscovered.add(n)) {
                     searchQueue.add(n);
-                    searchDiscovered.add(n);
                 }
             }
         }
+
+        drawerUpdatePriority();
     }
 
-    private IDrawerGroup getGroupForInvSlot(int invSlot) {
-        if (invSlot >= invSlotList.size()) return null;
+    /** Run each block tick */
+    public void updateOnTick() {
 
-        SlotRecord record = invSlotList.get(invSlot);
-        if (record == null) return null;
-
-        return getGroupForCoord(record.coord);
+        if (nextUpdate == controllerUpdateType.PRIORITY) {
+            this.drawerUpdatePriority();
+        } else if (nextUpdate == controllerUpdateType.FULL) {
+            this.fullDrawerUpdate();
+        }
+        nextUpdate = controllerUpdateType.NONE;
     }
 
-    private IDrawerGroup getGroupForDrawerSlot(int drawerSlot) {
+    /** On next updateOnTick() will run drawerUpdatePriority() */
+    public void schedulePriorityUpdate() {
+        if (nextUpdate.ordinal() < controllerUpdateType.PRIORITY.ordinal()) {
+            nextUpdate = controllerUpdateType.PRIORITY;
+        }
+    }
+
+    /** On next updateOnTick() will run fullDrawerUpdate() */
+    public void scheduleFullUpdate() {
+
+        if (nextUpdate.ordinal() < controllerUpdateType.FULL.ordinal()) {
+            nextUpdate = controllerUpdateType.FULL;
+        }
+    }
+
+    @Override
+    public void controllerFullUpdate() {
+        scheduleFullUpdate();
+    }
+
+    /** Should be called when registering a new item with a drawer registered with this controller */
+    public void setLookup(@NotNull ItemStack itemPrototype, int drawerSlot, List<ItemStack> oreDictMatches) {
+
+        drawerPrimaryLookup.register(
+                itemPrototype.getItem(),
+                itemPrototype.getItemDamage(),
+                drawerSlotList.get(drawerSlot),
+                oreDictMatches);
+
+        schedulePriorityUpdate();
+    }
+
+    /** Should be called when setting a stored item in a drawer registered with this controller to null */
+    public void removeLookup(@NotNull ItemStack itemPrototype, int drawerSlot, List<ItemStack> oreDictMatches) {
+
+        drawerPrimaryLookup.remove(
+                itemPrototype.getItem(),
+                itemPrototype.getItemDamage(),
+                drawerSlotList.get(drawerSlot),
+                oreDictMatches);
+
+        // Ensure emptyDrawerSlot is set to the lowest priority empty priorityIndex (Should usually have lower index as
+        // previously had item so had a higher priority)
+        int emptyPriorityIndex = drawerSlotList.get(drawerSlot).priorityIndex;
+        if (emptyPriorityIndex != -1 && emptyPriorityIndex < emptyDrawerSlot) {
+            emptyDrawerSlot = emptyPriorityIndex;
+        }
+
+        schedulePriorityUpdate();
+    }
+
+    private @Nullable IDrawerGroup getGroupForDrawerSlot(int drawerSlot) {
         if (drawerSlot >= drawerSlotList.size()) return null;
 
         SlotRecord record = drawerSlotList.get(drawerSlot);
@@ -606,29 +670,21 @@ public class TileEntityController extends TileEntity
     }
 
     private IDrawerGroup getGroupForCoord(BlockCoord coord) {
+
         if (coord == null) return null;
 
-        StorageRecord record = storage.get(coord);
-        if (record == null) return null;
+        IDrawerGroup drawerGroup = storage.get(coord);
+        if (drawerGroup == null) return null;
 
-        if (record.storage instanceof TileEntity) {
-            TileEntity tile = (TileEntity) record.storage;
+        if (drawerGroup instanceof TileEntity) {
+            TileEntity tile = (TileEntity) drawerGroup;
             if (tile.isInvalid() && tile != worldObj.getTileEntity(coord.x(), coord.y(), coord.z())) {
                 storage.remove(coord);
                 return null;
             }
         }
 
-        return record.storage;
-    }
-
-    private int getLocalInvSlot(int invSlot) {
-        if (invSlot >= invSlotList.size()) return 0;
-
-        SlotRecord record = invSlotList.get(invSlot);
-        if (record == null) return 0;
-
-        return record.slot;
+        return drawerGroup;
     }
 
     private int getLocalDrawerSlot(int drawerSlot) {
@@ -640,31 +696,40 @@ public class TileEntityController extends TileEntity
         return record.slot;
     }
 
-    private IDrawerInventory getDrawerInventory(int invSlot) {
-        IDrawerGroup group = getGroupForInvSlot(invSlot);
-        if (group == null) return null;
-
-        return group.getDrawerInventory();
-    }
-
     @Override
     public void readFromNBT(NBTTagCompound tag) {
+
         super.readFromNBT(tag);
 
         setDirection(tag.getByte("Dir"));
 
         if (tag.hasKey("CustomName", Constants.NBT.TAG_STRING)) customName = tag.getString("CustomName");
 
-        if (worldObj != null && !worldObj.isRemote) updateCache();
+        if (tag.hasKey("clientAutoSync")) enableClientAutoSync = tag.getBoolean("clientAutoSync");
+
+        if (tag.hasKey("IInventoryExtract")) {
+            IInventoryExtract = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("IInventoryExtract"));
+        } else {
+            IInventoryExtract = null;
+        }
+
+        if (worldObj != null && !worldObj.isRemote) scheduleFullUpdate();
     }
 
     @Override
     public void writeToNBT(NBTTagCompound tag) {
+
         super.writeToNBT(tag);
 
         tag.setByte("Dir", (byte) direction);
 
         if (hasCustomInventoryName()) tag.setString("CustomName", customName);
+
+        tag.setBoolean("clientAutoSync", enableClientAutoSync);
+
+        if (IInventoryExtract != null) {
+            tag.setTag("IInventoryExtract", IInventoryExtract.writeToNBT(new NBTTagCompound()));
+        }
     }
 
     @Override
@@ -676,7 +741,7 @@ public class TileEntityController extends TileEntity
     }
 
     @Override
-    public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
+    public void onDataPacket(NetworkManager net, @NotNull S35PacketUpdateTileEntity pkt) {
         readFromNBT(pkt.func_148857_g());
         getWorldObj().func_147479_m(xCoord, yCoord, zCoord); // markBlockForRenderUpdate
     }
@@ -685,6 +750,18 @@ public class TileEntityController extends TileEntity
     public IDrawerInventory getDrawerInventory() {
         return null;
     }
+
+    @Override
+    public BlockCoord getControllerCoord() {
+        return new BlockCoord(xCoord, yCoord, zCoord);
+    }
+
+    @Override
+    public void setControllerCoord(int sourceControllerX, int sourceControllerY, int sourceControllerZ) {}
+
+    @Override
+    public void clearControllerVariables(int sourceControllerX, int sourceControllerY, int sourceControllerZ,
+            boolean nullController) {}
 
     @Override
     public int getDrawerCount() {
@@ -714,9 +791,9 @@ public class TileEntityController extends TileEntity
 
     @Override
     public void markDirty() {
-        for (StorageRecord record : storage.values()) {
-            IDrawerGroup group = record.storage;
-            if (group != null && group.getDrawerInventory() != null) group.markDirtyIfNeeded();
+
+        for (IDrawerGroup drawerGroup : storage.values()) {
+            if (drawerGroup != null && drawerGroup.getDrawerInventory() != null) drawerGroup.markDirtyIfNeeded();
         }
 
         super.markDirty();
@@ -726,9 +803,9 @@ public class TileEntityController extends TileEntity
     public boolean markDirtyIfNeeded() {
         boolean synced = false;
 
-        for (StorageRecord record : storage.values()) {
-            IDrawerGroup group = record.storage;
-            if (group != null && group.getDrawerInventory() != null) synced |= group.markDirtyIfNeeded();
+        for (IDrawerGroup drawerGroup : storage.values()) {
+            if (drawerGroup != null && drawerGroup.getDrawerInventory() != null)
+                synced |= drawerGroup.markDirtyIfNeeded();
         }
 
         if (synced) super.markDirty();
@@ -736,89 +813,382 @@ public class TileEntityController extends TileEntity
         return synced;
     }
 
-    @Override
-    public int[] getAccessibleSlotsFromSide(int side) {
-        for (int aside : autoSides) {
-            if (side == aside) return inventorySlots;
-        }
+    // Inserting/Extracting using IInventory/ISidedInventory interfaces
 
-        return emptySlots;
+    public ItemStack getExtractionItem() {
+        return IInventoryExtract;
     }
 
-    @Override
-    public boolean canInsertItem(int slot, ItemStack stack, int side) {
-        IDrawerInventory inventory = getDrawerInventory(slot);
-        if (inventory == null) return false;
-
-        if (slot >= invSlotList.size()) return false;
-
-        SlotRecord record = invSlotList.get(slot);
-        List<SlotRecord> primaryRecords = invPrimaryLookup.getEntries(stack.getItem(), stack.getItemDamage());
-        if (primaryRecords != null && !primaryRecords.contains(record)) {
-            for (SlotRecord candidate : primaryRecords) {
-                IDrawerGroup candidateGroup = getGroupForCoord(candidate.coord);
-                if (candidateGroup == null) continue;
-
-                IDrawerInventory candidateInventory = candidateGroup.getDrawerInventory();
-                if (candidateInventory.canInsertItem(candidate.slot, stack)) {
-                    IDrawer drawer = candidateGroup.getDrawer(candidate.slot);
-                    if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) return false;
-                    if (drawer.getRemainingCapacity() > 0) return false;
-                }
-            }
+    public void setExtractionItem(ItemStack stack) {
+        if (stack == null) {
+            IInventoryExtract = null;
+        } else {
+            IInventoryExtract = stack.copy();
+            IInventoryExtract.stackSize = 1;
         }
-
-        return inventory.canInsertItem(getLocalInvSlot(slot), stack);
-    }
-
-    @Override
-    public boolean canExtractItem(int slot, ItemStack stack, int side) {
-        IDrawerInventory inventory = getDrawerInventory(slot);
-        if (inventory == null) return false;
-
-        return inventory.canExtractItem(getLocalInvSlot(slot), stack);
+        markDirty();
     }
 
     @Override
     public int getSizeInventory() {
-        return inventorySlots.length;
+        return 2;
+    }
+
+    @Override
+    public int[] getAccessibleSlotsFromSide(int side) {
+
+        if (side >= 0 && side <= 5) {
+            return virtualSlots;
+        }
+        return emptySlots;
     }
 
     @Override
     public ItemStack getStackInSlot(int slot) {
-        IDrawerInventory inventory = getDrawerInventory(slot);
-        if (inventory == null) return null;
 
-        return inventory.getStackInSlot(getLocalInvSlot(slot));
+        // Insertion
+        if (slot == 0 || IInventoryExtract == null) return null;
+
+        // Extraction
+        int amount = 0;
+        for (int drawerSlot : enumerateDrawersForExtraction(IInventoryExtract, true)) {
+            IDrawer drawer = getDrawer(drawerSlot);
+            amount += drawer.getStoredItemCount();
+            if (amount > this.getInventoryStackLimit()) {
+                amount = this.getInventoryStackLimit();
+                break;
+            }
+        }
+
+        if (amount == 0) {
+            return null;
+        }
+
+        ItemStack itemsLeft = IInventoryExtract.copy();
+        itemsLeft.stackSize = amount;
+        return itemsLeft;
     }
 
     @Override
-    public ItemStack decrStackSize(int slot, int count) {
-        IDrawerInventory inventory = getDrawerInventory(slot);
-        if (inventory == null) return null;
+    public boolean isItemValidForSlot(int slot, ItemStack stack) {
 
-        return inventory.decrStackSize(getLocalInvSlot(slot), count);
+        if (slot == 1) return false;
+
+        int itemsLeft = stack.stackSize;
+
+        for (int drawerSlot : enumerateDrawersForInsertion(stack, false)) {
+
+            IDrawer drawer = getDrawer(drawerSlot);
+
+            ItemStack itemProto = drawer.getStoredItemPrototype();
+            if (itemProto == null) {
+                return true;
+            }
+
+            itemsLeft = insertItemsIntoDrawer(drawer, itemsLeft, true);
+
+            if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) itemsLeft = 0;
+            if (itemsLeft == 0) return true;
+        }
+
+        return false;
     }
 
     @Override
-    public ItemStack getStackInSlotOnClosing(int slot) {
-        IDrawerInventory inventory = getDrawerInventory(slot);
-        if (inventory == null) return null;
+    public boolean canInsertItem(int slot, ItemStack stack, int side) {
+        return isItemValidForSlot(slot, stack);
+    }
 
-        return inventory.getStackInSlotOnClosing(getLocalInvSlot(slot));
+    @Override
+    public boolean canExtractItem(int slot, ItemStack stack, int side) {
+
+        if (slot == 0 || IInventoryExtract == null
+                || stack == null
+                || !stack.isItemEqual(IInventoryExtract)
+                || !ItemStack.areItemStackTagsEqual(stack, IInventoryExtract))
+            return false;
+
+        int itemsLeft = stack.stackSize;
+
+        for (int drawerSlot : enumerateDrawersForExtraction(stack, true)) {
+
+            IDrawer drawer = getDrawer(drawerSlot);
+            int itemCount = drawer.getStoredItemCount();
+
+            if (itemsLeft > itemCount) {
+                itemsLeft -= itemCount;
+            } else {
+                itemsLeft = 0;
+            }
+
+            if (itemsLeft == 0) return true;
+        }
+        return false;
     }
 
     @Override
     public void setInventorySlotContents(int slot, ItemStack stack) {
-        IDrawerInventory inventory = getDrawerInventory(slot);
-        if (inventory == null) return;
 
-        inventory.setInventorySlotContents(getLocalInvSlot(slot), stack);
-        inventory.markDirty();
+        // Insertion
+        if (slot == 0) {
+
+            if (stack == null) return;
+
+            int itemsLeft = stack.stackSize;
+
+            for (int drawerSlot : enumerateDrawersForInsertion(stack, false)) {
+
+                IDrawer drawer = getDrawer(drawerSlot);
+
+                ItemStack itemProto = drawer.getStoredItemPrototype();
+                if (itemProto == null) {
+                    drawer = drawer.setStoredItemRedir(stack, 0);
+                }
+
+                itemsLeft = insertItemsIntoDrawer(drawer, itemsLeft, false);
+
+                if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) itemsLeft = 0;
+                if (itemsLeft == 0) break;
+            }
+        }
+
+        // Extraction
+        else if (slot == 1 && IInventoryExtract != null) {
+
+            if (stack == null || (stack.isItemEqual(IInventoryExtract)
+                    && ItemStack.areItemStackTagsEqual(stack, IInventoryExtract))) {
+
+                // Get avaliable items in slot up to 64
+                int avaliableItems = 0;
+                for (int drawerSlot : enumerateDrawersForExtraction(IInventoryExtract, true)) {
+                    IDrawer drawer = getDrawer(drawerSlot);
+                    avaliableItems += drawer.getStoredItemCount();
+                    if (avaliableItems > this.getInventoryStackLimit()) {
+                        avaliableItems = this.getInventoryStackLimit();
+                        break;
+                    }
+                }
+
+                // Remove enough to make equal to stack.stackSize or 0 if stack is null
+                int toRemove = avaliableItems - ((stack == null) ? 0 : stack.stackSize);
+                for (int drawerSlot : enumerateDrawersForExtraction(IInventoryExtract, true)) {
+
+                    IDrawer drawer = getDrawer(drawerSlot);
+                    int itemCount = drawer.getStoredItemCount();
+
+                    if (toRemove > itemCount) {
+                        drawer.setStoredItemCount(0);
+                        toRemove -= itemCount;
+                    } else {
+                        drawer.setStoredItemCount(itemCount - toRemove);
+                        toRemove = 0;
+                    }
+                    if (toRemove == 0) break;
+                }
+            }
+        }
     }
+
+    @Override
+    public ItemStack decrStackSize(int slot, int count) {
+
+        if (slot == 0) return null;
+
+        int amountRemoved = 0;
+        for (int drawerSlot : enumerateDrawersForExtraction(IInventoryExtract, true)) {
+
+            IDrawer drawer = getDrawer(drawerSlot);
+            int itemCount = drawer.getStoredItemCount();
+
+            if (count > itemCount) {
+                drawer.setStoredItemCount(0);
+                amountRemoved += itemCount;
+                count -= itemCount;
+            } else {
+                drawer.setStoredItemCount(itemCount - count);
+                amountRemoved += (itemCount - count);
+                count = 0;
+            }
+
+            if (count == 0) return IInventoryExtract;
+        }
+
+        ItemStack itemsLeft = IInventoryExtract.copy();
+        itemsLeft.stackSize = amountRemoved;
+        return itemsLeft;
+    }
+
+    // Inserting/Extracting iterators
+
+    private class DrawerStackIteratorInsert implements Iterable<Integer> {
+
+        private final ItemStack stack;
+        private final boolean strict;
+
+        public DrawerStackIteratorInsert(ItemStack stack, boolean strict) {
+            this.stack = stack;
+            this.strict = strict;
+        }
+
+        @Override
+        public Iterator<Integer> iterator() {
+
+            if (this.stack == null) return new ArrayList<Integer>(0).iterator();
+
+            return new Iterator<Integer>() {
+
+                Iterator<SlotRecord> slotRecordIter = drawerPrimaryLookup
+                        .candidateIterator(stack.getItem(), stack.getItemDamage());
+                Integer nextSlot = null;
+
+                @Override
+                public boolean hasNext() {
+
+                    if (nextSlot == null) advance();
+
+                    return nextSlot != null;
+                }
+
+                @Override
+                public Integer next() {
+                    if (!hasNext()) throw new NoSuchElementException();
+
+                    Integer slot = nextSlot;
+                    nextSlot = null;
+                    return slot;
+                }
+
+                private void advance() {
+
+                    // For drawers that have an item (first check direct matches then oredict matches)
+                    if (slotRecordIter != null) {
+
+                        while (slotRecordIter.hasNext()) {
+
+                            SlotRecord candidate = slotRecordIter.next();
+                            IDrawerGroup candidateGroup = getGroupForCoord(candidate.coord);
+                            if (candidateGroup == null) continue;
+
+                            IDrawer drawer = candidateGroup.getDrawer(candidate.slot);
+
+                            if (strict) {
+                                ItemStack proto = drawer.getStoredItemPrototype();
+                                if (!proto.isItemEqual(stack)) continue;
+                            }
+
+                            boolean voiding = drawer instanceof IVoidable && ((IVoidable) drawer).isVoid();
+                            if (!drawer.canItemBeStored(stack) || (drawer.getRemainingCapacity() == 0 && !voiding))
+                                continue;
+
+                            nextSlot = candidate.listIndex;
+                            return;
+                        }
+                        slotRecordIter = null;
+                    }
+
+                    // For inserting a new item
+                    for (; emptyDrawerSlot < drawerSlots.length; emptyDrawerSlot++) {
+
+                        int slot = drawerSlots[emptyDrawerSlot];
+                        if (!isDrawerEnabled(slot)) continue;
+
+                        IDrawer drawer = getDrawer(slot);
+
+                        if (!(drawer.isEmpty() && drawer.canItemBeStored(stack))) continue;
+
+                        nextSlot = slot;
+                        return;
+                    }
+                }
+            };
+        }
+    };
+
+    private class DrawerStackIteratorExtract implements Iterable<Integer> {
+
+        private final ItemStack stack;
+        private final boolean strict;
+
+        public DrawerStackIteratorExtract(ItemStack stack, boolean strict) {
+            this.stack = stack;
+            this.strict = strict;
+        }
+
+        @Override
+        public Iterator<Integer> iterator() {
+
+            if (this.stack == null) return new ArrayList<Integer>(0).iterator();
+
+            return new Iterator<Integer>() {
+
+                final Iterator<SlotRecord> slotRecordIter = drawerPrimaryLookup
+                        .candidateIterator(stack.getItem(), stack.getItemDamage());
+
+                Integer nextSlot = null;
+
+                @Override
+                public boolean hasNext() {
+
+                    if (nextSlot == null) advance();
+
+                    return nextSlot != null;
+                }
+
+                @Override
+                public Integer next() {
+                    if (!hasNext()) throw new NoSuchElementException();
+
+                    Integer slot = nextSlot;
+                    nextSlot = null;
+                    return slot;
+                }
+
+                private void advance() {
+
+                    if (slotRecordIter != null) {
+
+                        while (slotRecordIter.hasNext()) {
+
+                            SlotRecord candidate = slotRecordIter.next();
+
+                            IDrawerGroup candidateGroup = getGroupForCoord(candidate.coord);
+                            if (candidateGroup == null) continue;
+
+                            IDrawer drawer = candidateGroup.getDrawer(candidate.slot);
+
+                            if (strict) {
+                                ItemStack proto = drawer.getStoredItemPrototype();
+                                if (!proto.isItemEqual(stack)) continue;
+                            }
+
+                            if (!drawer.canItemBeExtracted(stack) || drawer.getStoredItemCount() == 0) continue;
+
+                            nextSlot = candidate.listIndex;
+                            return;
+                        }
+                    }
+                }
+            };
+        }
+    };
+
+    public Iterable<Integer> enumerateDrawersForInsertion(ItemStack stack, boolean strict) {
+        return new DrawerStackIteratorInsert(stack, strict);
+    }
+
+    public Iterable<Integer> enumerateDrawersForExtraction(ItemStack stack, boolean strict) {
+        return new DrawerStackIteratorExtract(stack, strict);
+    }
+
+    // Other stuff
 
     public void setInventoryName(String name) {
         customName = name;
+    }
+
+    @Override
+    public ItemStack getStackInSlotOnClosing(int slot) {
+        return null;
     }
 
     @Override
@@ -828,7 +1198,7 @@ public class TileEntityController extends TileEntity
 
     @Override
     public boolean hasCustomInventoryName() {
-        return customName != null && customName.length() > 0;
+        return customName != null && !customName.isEmpty();
     }
 
     @Override
@@ -846,137 +1216,4 @@ public class TileEntityController extends TileEntity
 
     @Override
     public void closeInventory() {}
-
-    @Override
-    public boolean isItemValidForSlot(int slot, ItemStack stack) {
-        IDrawerInventory inventory = getDrawerInventory(slot);
-        if (inventory == null) return false;
-
-        if (slot >= invSlotList.size()) return false;
-
-        SlotRecord record = invSlotList.get(slot);
-        List<SlotRecord> primaryRecords = invPrimaryLookup.getEntries(stack.getItem(), stack.getItemDamage());
-        if (primaryRecords != null && !primaryRecords.contains(record)) {
-            for (SlotRecord candidate : primaryRecords) {
-                IDrawerGroup candidateGroup = getGroupForCoord(candidate.coord);
-                if (candidateGroup == null) continue;
-
-                IDrawerInventory candidateInventory = candidateGroup.getDrawerInventory();
-                if (candidateInventory.isItemValidForSlot(candidate.slot, stack)) {
-                    IDrawer drawer = candidateGroup.getDrawer(candidate.slot);
-                    if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) return false;
-                    if (drawer.getRemainingCapacity() > 0) return false;
-                }
-            }
-        }
-
-        return inventory.isItemValidForSlot(getLocalInvSlot(slot), stack);
-    }
-
-    private class DrawerStackIterator implements Iterable<Integer> {
-
-        private ItemStack stack;
-        private boolean strict;
-        private boolean insert;
-
-        public DrawerStackIterator(ItemStack stack, boolean strict, boolean insert) {
-            this.stack = stack;
-            this.strict = strict;
-            this.insert = insert;
-        }
-
-        @Override
-        public Iterator<Integer> iterator() {
-            if (this.stack == null) return new ArrayList<Integer>(0).iterator();
-
-            return new Iterator<Integer>() {
-
-                List<SlotRecord> primaryRecords = drawerPrimaryLookup
-                        .getEntries(stack.getItem(), stack.getItemDamage());
-                Iterator<SlotRecord> iter1;
-                int index2;
-                Integer nextSlot = null;
-
-                @Override
-                public boolean hasNext() {
-                    if (nextSlot == null) advance();
-                    return nextSlot != null;
-                }
-
-                @Override
-                public Integer next() {
-                    if (nextSlot == null) advance();
-
-                    Integer slot = nextSlot;
-                    nextSlot = null;
-                    return slot;
-                }
-
-                private void advance() {
-                    if (iter1 == null && primaryRecords != null && primaryRecords.size() > 0)
-                        iter1 = primaryRecords.iterator();
-
-                    if (iter1 != null) {
-                        while (iter1.hasNext()) {
-                            SlotRecord candidate = iter1.next();
-                            IDrawerGroup candidateGroup = getGroupForCoord(candidate.coord);
-                            if (candidateGroup == null) continue;
-
-                            IDrawer drawer = candidateGroup.getDrawer(candidate.slot);
-
-                            if (insert) {
-                                boolean voiding = (drawer instanceof IVoidable) ? ((IVoidable) drawer).isVoid() : false;
-                                if (!(drawer.canItemBeStored(stack)
-                                        && (drawer.isEmpty() || drawer.getRemainingCapacity() > 0 || voiding)))
-                                    continue;
-                            } else {
-                                if (!(drawer.canItemBeExtracted(stack) && drawer.getStoredItemCount() > 0)) continue;
-                            }
-
-                            int slot = drawerSlotList.indexOf(candidate);
-                            if (slot > -1) {
-                                nextSlot = slot;
-                                return;
-                            }
-                        }
-                    }
-
-                    for (; index2 < drawerSlots.length; index2++) {
-                        int slot = drawerSlots[index2];
-                        if (!isDrawerEnabled(slot)) continue;
-
-                        IDrawer drawer = getDrawer(slot);
-                        if (strict) {
-                            ItemStack proto = drawer.getStoredItemPrototype();
-                            if (proto != null && !proto.isItemEqual(stack)) continue;
-                        }
-
-                        if (insert) {
-                            boolean voiding = (drawer instanceof IVoidable) ? ((IVoidable) drawer).isVoid() : false;
-                            if (!(drawer.canItemBeStored(stack)
-                                    && (drawer.isEmpty() || drawer.getRemainingCapacity() > 0 || voiding)))
-                                continue;
-                        } else {
-                            if (!(drawer.canItemBeExtracted(stack) && drawer.getStoredItemCount() > 0)) continue;
-                        }
-
-                        SlotRecord record = drawerSlotList.get(slot);
-                        if (primaryRecords != null && primaryRecords.contains(record)) continue;
-
-                        nextSlot = slot;
-                        index2++;
-                        return;
-                    }
-                }
-            };
-        }
-    };
-
-    public Iterable<Integer> enumerateDrawersForInsertion(ItemStack stack, boolean strict) {
-        return new DrawerStackIterator(stack, strict, true);
-    }
-
-    public Iterable<Integer> enumerateDrawersForExtraction(ItemStack stack, boolean strict) {
-        return new DrawerStackIterator(stack, strict, false);
-    }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawers.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -58,8 +59,8 @@ public abstract class TileEntityDrawers extends BaseTileEntity
         implements IDrawerGroupInteractive, ISidedInventory, IUpgradeProvider, ILockable, ISealable, IProtectable,
         IDowngradable, CapabilityProvider, IExtendedBlockClickHandler {
 
-    private IDrawer[] drawers;
-    private IDrawerInventory inventory;
+    protected IDrawer[] drawers;
+    protected IDrawerInventory inventory;
 
     private int direction;
     private int drawerCapacity = 1;
@@ -84,6 +85,72 @@ public abstract class TileEntityDrawers extends BaseTileEntity
     private ItemStack materialSide;
     private ItemStack materialFront;
     private ItemStack materialTrim;
+
+    private boolean isFirstTick = true;
+    protected TileEntityController controller = null;
+    protected BlockCoord controllerCoord = null;
+
+    @Override
+    public void controllerFullUpdate() {
+
+        if (controller != null && !controller.isInvalid()) {
+            controller.scheduleFullUpdate();
+        }
+    }
+
+    @Override
+    public BlockCoord getControllerCoord() {
+        return controllerCoord;
+    }
+
+    @Override
+    public void setControllerCoord(int sourceControllerX, int sourceControllerY, int sourceControllerZ) {
+
+        if (controllerCoord == null || controllerCoord.x() != sourceControllerX
+                || controllerCoord.y() != sourceControllerY
+                || controllerCoord.z() != sourceControllerZ) {
+            controllerCoord = new BlockCoord(sourceControllerX, sourceControllerY, sourceControllerZ);
+            markDirty();
+        }
+
+        if (worldObj == null) return;
+
+        TileEntity te = worldObj.getTileEntity(controllerCoord.x(), controllerCoord.y(), controllerCoord.z());
+        if (te instanceof TileEntityController) {
+            controller = (TileEntityController) te;
+        }
+    }
+
+    @Override
+    public void clearControllerVariables(int sourceControllerX, int sourceControllerY, int sourceControllerZ,
+            boolean nullController) {
+
+        if (controllerCoord == null || controllerCoord.x() != sourceControllerX
+                || controllerCoord.y() != sourceControllerY
+                || controllerCoord.z() != sourceControllerZ) {
+
+            for (IDrawer drawer : drawers) {
+                drawer.clearTileEntityController();
+            }
+
+            if (nullController) {
+                controllerCoord = null;
+                controller = null;
+                markDirty();
+            }
+        }
+    }
+
+    /**
+     * For interactions that change controller drawer priority (e.g. void upgrade, locking, sealing) reschedule
+     * controller priority update.
+     */
+    public void controllerSchedulePriorityUpdate() {
+
+        if (controller != null && !controller.isInvalid()) {
+            controller.schedulePriorityUpdate();
+        }
+    }
 
     protected TileEntityDrawers(int drawerCount) {
         initWithDrawerCount(drawerCount);
@@ -173,12 +240,16 @@ public abstract class TileEntityDrawers extends BaseTileEntity
     }
 
     public void setUpgrade(int slot, ItemStack upgrade) {
+
         slot = MathHelper.clamp_int(slot, 0, 4);
 
         if (upgrade != null) {
             upgrade = upgrade.copy();
             upgrade.stackSize = 1;
+
         }
+
+        controllerSchedulePriorityUpdate();
 
         upgrades[slot] = upgrade;
 
@@ -230,12 +301,16 @@ public abstract class TileEntityDrawers extends BaseTileEntity
             if (lockAttributes == null) lockAttributes = EnumSet.of(attr);
             else lockAttributes.add(attr);
 
+            controllerSchedulePriorityUpdate();
+
             if (worldObj != null && !worldObj.isRemote) {
                 markDirty();
                 worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
             }
         } else if (!isLocked && lockAttributes != null && lockAttributes.contains(attr)) {
+
             lockAttributes.remove(attr);
+            controllerSchedulePriorityUpdate();
 
             if (worldObj != null && !worldObj.isRemote) {
                 markDirty();
@@ -348,6 +423,8 @@ public abstract class TileEntityDrawers extends BaseTileEntity
         if (this.taped != state) {
             this.taped = state;
 
+            controllerSchedulePriorityUpdate();
+
             if (worldObj != null && !worldObj.isRemote) {
                 markDirty();
                 worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
@@ -396,6 +473,10 @@ public abstract class TileEntityDrawers extends BaseTileEntity
 
         int amount = getTakeAmount(player, invertShift, drawer);
         ItemStack item = takeItemsFromSlot(slot, amount, player, isHoldingClick);
+
+        if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+            controller.syncClient();
+        }
 
         traceItem(item);
 
@@ -606,6 +687,7 @@ public abstract class TileEntityDrawers extends BaseTileEntity
      * Returns an ItemStack that will have a maximum size of {@link ItemStack#getMaxStackSize()}
      */
     public ItemStack takeItemsFromSlot(int slot, int count, EntityPlayer player, boolean isHoldingClick) {
+
         if (slot < 0 || slot >= getDrawerCount()) return null;
 
         ItemStack stack = getItemsFromSlot(slot, count);
@@ -637,6 +719,7 @@ public abstract class TileEntityDrawers extends BaseTileEntity
     }
 
     public ItemStack takeItemsFromSlotWithDestroy(int slot, int count) {
+
         if (slot < 0 || slot >= getDrawerCount()) return null;
 
         ItemStack stack = getItemsFromSlot(slot, count);
@@ -657,6 +740,7 @@ public abstract class TileEntityDrawers extends BaseTileEntity
      * Returns an ItemStack that will have a maximum size of {@link ItemStack#getMaxStackSize()}
      */
     protected ItemStack getItemsFromSlot(int slot, int count) {
+
         if (drawers[slot].isEmpty()) return null;
 
         ItemStack stack = drawers[slot].getStoredItemCopy();
@@ -667,6 +751,7 @@ public abstract class TileEntityDrawers extends BaseTileEntity
     }
 
     public int putItemsIntoSlot(int slot, ItemStack stack, int count) {
+
         if (slot < 0 || slot >= getDrawerCount()) return 0;
 
         IDrawer drawer = drawers[slot];
@@ -714,16 +799,29 @@ public abstract class TileEntityDrawers extends BaseTileEntity
         return count;
     }
 
-    public int interactPutItemsIntoSlot(int slot, EntityPlayer player) {
+    public void interactPutItemsIntoSlot(int slot, EntityPlayer player) {
+
         int count = 0;
-        if (worldObj.getTotalWorldTime() - lastClickTime < 10 && player.getPersistentID().equals(lastClickUUID))
+        if (worldObj.getTotalWorldTime() - lastClickTime < 10 && player.getPersistentID().equals(lastClickUUID)) {
             count = interactPutCurrentInventoryIntoSlot(slot, player);
-        else count = interactPutCurrentItemIntoSlot(slot, player);
+        } else count = interactPutCurrentItemIntoSlot(slot, player);
 
         lastClickTime = worldObj.getTotalWorldTime();
         lastClickUUID = player.getPersistentID();
 
-        return count;
+        IDrawer drawer = getDrawer(slot);
+
+        // Sync with client
+        if (drawer != null) {
+
+            if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+                controller.syncClient();
+            } else {
+                ItemStack currentStack = drawer.getStoredItemPrototype();
+                if (count > 0 && currentStack != null) worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+            }
+
+        }
     }
 
     private void readLegacyUpgradeNBT(NBTTagCompound tag) {
@@ -736,6 +834,7 @@ public abstract class TileEntityDrawers extends BaseTileEntity
 
     @Override
     protected void readFromFixedNBT(NBTTagCompound tag) {
+
         super.readFromFixedNBT(tag);
 
         setDirection(tag.getByte("Dir"));
@@ -747,10 +846,20 @@ public abstract class TileEntityDrawers extends BaseTileEntity
         if (tag.hasKey("CustomName", Constants.NBT.TAG_STRING)) customName = tag.getString("CustomName");
 
         downgraded = tag.hasKey("Down") && tag.getBoolean("Down");
+
+        controllerCoord = null;
+        if (tag.hasKey("controllerCoords", Constants.NBT.TAG_COMPOUND)) {
+            NBTTagCompound ctag = tag.getCompoundTag("controllerCoords");
+            controllerCoord = new BlockCoord(
+                    ctag.getInteger("xController"),
+                    ctag.getInteger("yController"),
+                    ctag.getInteger("zController"));
+        }
     }
 
     @Override
     protected void writeToFixedNBT(NBTTagCompound tag) {
+
         super.writeToFixedNBT(tag);
 
         tag.setByte("Dir", (byte) direction);
@@ -760,10 +869,19 @@ public abstract class TileEntityDrawers extends BaseTileEntity
         if (hasCustomInventoryName()) tag.setString("CustomName", customName);
 
         if (checkDowngraded()) tag.setBoolean("Down", downgraded);
+
+        if (controllerCoord != null) {
+            NBTTagCompound ctag = new NBTTagCompound();
+            ctag.setInteger("xController", controllerCoord.x());
+            ctag.setInteger("yController", controllerCoord.y());
+            ctag.setInteger("zController", controllerCoord.z());
+            tag.setTag("controllerCoords", ctag);
+        }
     }
 
     @Override
     public void readFromPortableNBT(NBTTagCompound tag) {
+
         super.readFromPortableNBT(tag);
 
         upgrades = new ItemStack[upgrades.length];
@@ -819,8 +937,6 @@ public abstract class TileEntityDrawers extends BaseTileEntity
 
         materialTrim = null;
         if (tag.hasKey("MatT")) materialTrim = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("MatT"));
-
-        io = null; // Rebuild ItemIO after drawer slots are recreated.
     }
 
     @Override
@@ -882,12 +998,29 @@ public abstract class TileEntityDrawers extends BaseTileEntity
     }
 
     @Override
+    public void updateEntity() {
+
+        if (isFirstTick && worldObj != null && !worldObj.isRemote && controllerCoord != null) {
+
+            isFirstTick = false;
+
+            TileEntity te = worldObj.getTileEntity(controllerCoord.x(), controllerCoord.y(), controllerCoord.z());
+
+            if (te instanceof TileEntityController) {
+                controller = ((TileEntityController) te);
+                ((TileEntityController) te).scheduleFullUpdate();
+            }
+        }
+    }
+
+    @Override
     public boolean canUpdate() {
         return false;
     }
 
     @Override
     public void markDirty() {
+
         inventory.markDirty();
         if (isRedstone() && worldObj != null) {
             worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, getBlockType());
@@ -927,14 +1060,22 @@ public abstract class TileEntityDrawers extends BaseTileEntity
         if (drawer.getStoredItemCount() != count) {
             drawer.setStoredItemCount(count);
 
-            switch (getEffectiveStatusLevel()) {
-                case 1:
-                    if (drawer.getStoredItemCount() == 0 || drawer.getRemainingCapacity() == 0)
-                        getWorldObj().func_147479_m(xCoord, yCoord, zCoord); // markBlockForRenderUpdate
-                    break;
-                case 2:
-                    getWorldObj().func_147479_m(xCoord, yCoord, zCoord); // markBlockForRenderUpdate
-                    break;
+            int statusLevel = getEffectiveStatusLevel();
+
+            if (statusLevel == 0) {
+                drawer.setStoredItemCount(count);
+            } else if (statusLevel == 1) {
+                int capacityBefore = drawer.getRemainingCapacity();
+                drawer.setStoredItemCount(count);
+                int capacityAfter = drawer.getRemainingCapacity();
+
+                if (capacityBefore != capacityAfter) getWorldObj().func_147479_m(xCoord, yCoord, zCoord); // markBlockForRenderUpdate
+
+            } else if (statusLevel == 2) {
+                drawer.setStoredItemCount(count);
+                getWorldObj().func_147479_m(xCoord, yCoord, zCoord); // markBlockForRenderUpdate
+            } else {
+                drawer.setStoredItemCount(count);
             }
         }
     }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntityDrawersComp.java
@@ -20,7 +20,6 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
 import com.jaquadro.minecraft.storagedrawers.config.CompTierRegistry;
 import com.jaquadro.minecraft.storagedrawers.config.ConfigManager;
-import com.jaquadro.minecraft.storagedrawers.network.CountUpdateMessage;
 import com.jaquadro.minecraft.storagedrawers.storage.BaseDrawerData;
 import com.jaquadro.minecraft.storagedrawers.storage.CompDrawerData;
 import com.jaquadro.minecraft.storagedrawers.storage.DrawerData;
@@ -28,8 +27,6 @@ import com.jaquadro.minecraft.storagedrawers.storage.ICentralInventory;
 import com.jaquadro.minecraft.storagedrawers.util.ItemStackConversion;
 
 import cpw.mods.fml.common.FMLLog;
-import cpw.mods.fml.common.network.NetworkRegistry;
-import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.registry.GameData;
 import cpw.mods.fml.common.registry.GameRegistry;
 
@@ -52,6 +49,35 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
 
         protoStack = new ItemStack[getDrawerCount()];
         convRate = new int[getDrawerCount()];
+    }
+
+    public void setLookupController(int slot, ItemStack itemPrototype, TileEntityController controller,
+            int controllerDrawerSlot, List<ItemStack> oreDictMatches) {
+
+        if (controller == null || controller.isInvalid() || controllerDrawerSlot == -1) {
+
+            drawers[slot].clearTileEntityController();
+        } else if (itemPrototype != null) {
+            controller.setLookup(
+                    itemPrototype,
+                    controllerDrawerSlot,
+                    StorageDrawers.config.cache.enableItemConversion ? oreDictMatches : null);
+        }
+    }
+
+    public void removeLookupController(int slot, TileEntityController controller, int controllerDrawerSlot) {
+
+        if (controller == null || controller.isInvalid() || controllerDrawerSlot == -1) {
+
+            drawers[slot].clearTileEntityController();
+
+        } else if (protoStack[slot] != null) {
+
+            controller.removeLookup(
+                    protoStack[slot],
+                    controllerDrawerSlot,
+                    StorageDrawers.config.cache.enableItemConversion ? drawers[slot].getOreDictMatches() : null);
+        }
     }
 
     protected ICentralInventory getCentralInventory() {
@@ -92,6 +118,13 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
             for (int i = 0; i < getDrawerCount(); i++) {
                 IDrawer drawer = getDrawer(i);
                 if (drawer instanceof CompDrawerData) ((CompDrawerData) drawer).refresh();
+
+                setLookupController(
+                        i,
+                        protoStack[i],
+                        drawers[i].getController(),
+                        drawers[i].getControllerDrawerSlot(),
+                        drawers[i].getOreDictMatches());
             }
         }
 
@@ -151,6 +184,7 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
     }
 
     private void populateSlots(ItemStack stack) {
+
         int index = 0;
 
         ItemStack uTier1 = findHigherTier(stack);
@@ -204,12 +238,11 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
     }
 
     private void populateSlot(int slot, ItemStack stack, int conversion) {
+
         convRate[slot] = conversion;
         protoStack[slot] = stack.copy();
-        // centralInventory.setStoredItem(slot, stack, 0);
-        // getDrawer(slot).setStoredItem(stack, 0);
 
-        if (worldObj != null && worldObj.isRemote) getWorldObj().func_147479_m(xCoord, yCoord, zCoord); // markBlockForRenderUpdate
+        if (worldObj != null && worldObj.isRemote) getWorldObj().func_147479_m(xCoord, yCoord, zCoord);
     }
 
     private ItemStack findHigherTier(ItemStack stack) {
@@ -497,6 +530,7 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
 
         @Override
         public IDrawer setStoredItem(int slot, ItemStack itemPrototype, int amount) {
+
             if (itemPrototype != null && convRate != null && convRate[0] == 0) {
                 IDrawer target = null;
                 populateSlots(itemPrototype);
@@ -508,23 +542,43 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
                 }
 
                 for (int i = 0; i < getDrawerCount(); i++) {
-                    if (i == slot) continue;
 
                     IDrawer drawer = getDrawer(i);
+
                     if (drawer instanceof CompDrawerData) ((CompDrawerData) drawer).refresh();
+
+                    setLookupController(
+                            i,
+                            protoStack[i],
+                            drawers[i].getController(),
+                            drawers[i].getControllerDrawerSlot(),
+                            drawers[i].getOreDictMatches());
                 }
 
                 if (worldObj != null && !worldObj.isRemote) {
-                    // TileEntityDrawersComp.this.markDirty();
-                    worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+
+                    if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+                        controller.addClientSyncList(xCoord, yCoord, zCoord);
+                    } else {
+                        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                    }
                 }
 
                 return target;
             } else if (itemPrototype == null) {
-                // setStoredItemCount(slot, 0);
+
                 pooledCount = 0;
+
                 clear();
-                if (worldObj != null && !worldObj.isRemote) worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+
+                if (worldObj != null && !worldObj.isRemote) {
+
+                    if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+                        controller.addClientSyncList(xCoord, yCoord, zCoord);
+                    } else {
+                        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                    }
+                }
             }
 
             return getDrawer(slot);
@@ -540,7 +594,9 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
         }
 
         @Override
-        public void setStoredItemCount(int slot, int amount) {
+        public void setStoredItemCount(int slot, int amount, TileEntityController controller,
+                int controllerDrawerSlot) {
+
             if (convRate == null || convRate[slot] == 0) return;
 
             if (TileEntityDrawersComp.this.isVending()) return;
@@ -552,13 +608,27 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
             if (pooledCount > poolMax) pooledCount = poolMax;
 
             if (pooledCount != oldCount) {
-                if (pooledCount != 0 || TileEntityDrawersComp.this.isLocked(LockAttribute.LOCK_POPULATED))
-                    markAmountDirty();
-                else {
-                    clear();
-                    if (worldObj != null && !worldObj.isRemote) {
-                        // TileEntityDrawersComp.this.markDirty();
+
+                if (pooledCount != 0 || TileEntityDrawersComp.this.isLocked(LockAttribute.LOCK_POPULATED)) {
+
+                    if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+                        controller.addClientSyncList(xCoord, yCoord, zCoord);
+                    } else {
                         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                    }
+                }
+
+                else {
+
+                    clear();
+
+                    if (worldObj != null && !worldObj.isRemote) {
+
+                        if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+                            controller.addClientSyncList(xCoord, yCoord, zCoord);
+                        } else {
+                            worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                        }
                     }
                 }
             }
@@ -682,6 +752,9 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
 
         private void clear() {
             for (int i = 0; i < getDrawerCount(); i++) {
+
+                removeLookupController(i, drawers[i].getController(), drawers[i].getControllerDrawerSlot());
+
                 protoStack[i] = null;
                 convRate[i] = 0;
             }
@@ -710,26 +783,6 @@ public class TileEntityDrawersComp extends TileEntityDrawers {
             ConfigManager config = StorageDrawers.config;
             return TileEntityDrawersComp.this.getEffectiveStorageMultiplier()
                     * TileEntityDrawersComp.this.getDrawerCapacity();
-        }
-
-        public void markAmountDirty() {
-            if (getWorldObj().isRemote) return;
-
-            IMessage message = new CountUpdateMessage(xCoord, yCoord, zCoord, 0, pooledCount);
-            NetworkRegistry.TargetPoint targetPoint = new NetworkRegistry.TargetPoint(
-                    getWorldObj().provider.dimensionId,
-                    xCoord,
-                    yCoord,
-                    zCoord,
-                    500);
-
-            StorageDrawers.network.sendToAllAround(message, targetPoint);
-        }
-
-        public void markDirty(int slot) {
-            if (getWorldObj().isRemote) return;
-
-            getWorldObj().markBlockForUpdate(xCoord, yCoord, zCoord);
         }
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntitySlave.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/block/tile/TileEntitySlave.java
@@ -17,31 +17,34 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IPriorityGroup;
 import com.jaquadro.minecraft.storagedrawers.api.storage.ISmartGroup;
+import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.IVoidable;
 
 public class TileEntitySlave extends TileEntity implements IDrawerGroup, IPriorityGroup, ISmartGroup, ISidedInventory {
-
-    private BlockCoord controllerCoord;
-    private BlockCoord selfCoord;
 
     private int[] inventorySlots = new int[] { 0 };
     private int[] drawerSlots = new int[] { 0 };
 
-    public void ensureInitialized() {
-        if (selfCoord == null) {
-            selfCoord = new BlockCoord(xCoord, yCoord, zCoord);
-            markDirty();
-        }
-    }
+    private BlockCoord controllerCoord;
+    private TileEntityController controller = null;
+    private boolean isFirstTick = true;
+
+    // Item that this Entity can extract with IInventory interface (Vanilla hoppers and Pipes. Only 1 item to reduce
+    // overhead of otherwise having to cycling though many slots)
+    private ItemStack IInventoryExtract;
 
     @Override
     public void readFromNBT(NBTTagCompound tag) {
-        super.readFromNBT(tag);
 
-        selfCoord = new BlockCoord(xCoord, yCoord, zCoord);
+        super.readFromNBT(tag);
 
         if (tag.hasKey("Controller", Constants.NBT.TAG_COMPOUND)) {
             NBTTagCompound ctag = tag.getCompoundTag("Controller");
             controllerCoord = new BlockCoord(ctag.getInteger("x"), ctag.getInteger("y"), ctag.getInteger("z"));
+        }
+        if (tag.hasKey("IInventoryExtract")) {
+            IInventoryExtract = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("IInventoryExtract"));
+        } else {
+            IInventoryExtract = null;
         }
     }
 
@@ -55,6 +58,9 @@ public class TileEntitySlave extends TileEntity implements IDrawerGroup, IPriori
             ctag.setInteger("y", controllerCoord.y());
             ctag.setInteger("z", controllerCoord.z());
             tag.setTag("Controller", ctag);
+        }
+        if (IInventoryExtract != null) {
+            tag.setTag("IInventoryExtract", IInventoryExtract.writeToNBT(new NBTTagCompound()));
         }
     }
 
@@ -72,114 +78,238 @@ public class TileEntitySlave extends TileEntity implements IDrawerGroup, IPriori
         getWorldObj().func_147479_m(xCoord, yCoord, zCoord); // markBlockForRenderUpdate
     }
 
-    public void bindController(int x, int y, int z) {
-        if (controllerCoord != null && controllerCoord.x() == x && controllerCoord.y() == y && controllerCoord.z() == z)
-            return;
-
-        controllerCoord = new BlockCoord(x, y, z);
-        markDirty();
-    }
-
-    public TileEntityController getController() {
-        if (controllerCoord == null) return null;
-
-        ensureInitialized();
-
-        TileEntity te = worldObj.getTileEntity(controllerCoord.x(), controllerCoord.y(), controllerCoord.z());
-        if (!(te instanceof TileEntityController)) {
-            controllerCoord = null;
-            markDirty();
-            return null;
-        }
-
-        return (TileEntityController) te;
-    }
-
     @Override
     public int[] getAccessibleDrawerSlots() {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return drawerSlots;
-
+        if (controller == null || controller.isInvalid()) return drawerSlots;
         return controller.getAccessibleDrawerSlots();
     }
 
-    @Override
-    public int[] getAccessibleSlotsFromSide(int side) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return inventorySlots;
+    // =================================================================================================================
 
-        return controller.getAccessibleSlotsFromSide(0);
+    public ItemStack getExtractionItem() {
+        return IInventoryExtract;
     }
 
-    @Override
-    public boolean canInsertItem(int slot, ItemStack stack, int side) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return false;
-
-        return controller.canInsertItem(slot, stack, 0);
-    }
-
-    @Override
-    public boolean canExtractItem(int slot, ItemStack stack, int side) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return false;
-
-        return controller.canExtractItem(slot, stack, side);
+    public void setExtractionItem(ItemStack stack) {
+        if (stack == null) {
+            IInventoryExtract = null;
+        } else {
+            IInventoryExtract = stack.copy();
+            IInventoryExtract.stackSize = 1;
+        }
+        markDirty();
     }
 
     @Override
     public int getSizeInventory() {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return 1;
-
+        if (controller == null || controller.isInvalid()) return 0;
         return controller.getSizeInventory();
     }
 
     @Override
+    public int[] getAccessibleSlotsFromSide(int side) {
+        if (controller == null || controller.isInvalid()) return inventorySlots;
+        return controller.getAccessibleSlotsFromSide(0);
+    }
+
+    @Override
     public ItemStack getStackInSlot(int slot) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return null;
 
-        return controller.getStackInSlot(slot);
+        // Insertion (slot 0)
+        if (slot == 0 || IInventoryExtract == null) return null;
+        if (controller == null || controller.isInvalid()) return null;
+
+        // Extraction (slot 1)
+        int amount = 0;
+        for (int drawerSlot : controller.enumerateDrawersForExtraction(IInventoryExtract, true)) {
+            IDrawer drawer = controller.getDrawer(drawerSlot);
+            amount += drawer.getStoredItemCount();
+            if (amount > this.getInventoryStackLimit()) {
+                amount = this.getInventoryStackLimit();
+                break;
+            }
+        }
+
+        if (amount == 0) {
+            return null;
+        }
+
+        ItemStack stackView = IInventoryExtract.copy();
+        stackView.stackSize = amount;
+        return stackView;
     }
 
     @Override
-    public ItemStack decrStackSize(int slot, int count) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return null;
+    public boolean isItemValidForSlot(int slot, ItemStack stack) {
 
-        return controller.decrStackSize(slot, count);
+        if (slot == 1) return false;
+        if (controller == null || controller.isInvalid()) return false;
+
+        int itemsLeft = stack.stackSize;
+
+        for (int drawerSlot : controller.enumerateDrawersForInsertion(stack, false)) {
+
+            IDrawer drawer = controller.getDrawer(drawerSlot);
+
+            ItemStack itemProto = drawer.getStoredItemPrototype();
+            if (itemProto == null) {
+                return true;
+            }
+
+            itemsLeft = controller.insertItemsIntoDrawer(drawer, itemsLeft, true);
+
+            if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) itemsLeft = 0;
+            if (itemsLeft == 0) return true;
+        }
+
+        return false;
     }
 
     @Override
-    public ItemStack getStackInSlotOnClosing(int slot) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return null;
+    public boolean canInsertItem(int slot, ItemStack stack, int side) {
+        return isItemValidForSlot(slot, stack);
+    }
 
-        return controller.getStackInSlotOnClosing(slot);
+    @Override
+    public boolean canExtractItem(int slot, ItemStack stack, int side) {
+
+        if (slot == 0 || IInventoryExtract == null
+                || stack == null
+                || !stack.isItemEqual(IInventoryExtract)
+                || !ItemStack.areItemStackTagsEqual(stack, IInventoryExtract))
+            return false;
+
+        if (controller == null || controller.isInvalid()) return false;
+
+        int itemsLeft = stack.stackSize;
+
+        for (int drawerSlot : controller.enumerateDrawersForExtraction(stack, true)) {
+
+            IDrawer drawer = controller.getDrawer(drawerSlot);
+            int itemCount = drawer.getStoredItemCount();
+
+            if (itemsLeft > itemCount) {
+                itemsLeft -= itemCount;
+            } else {
+                itemsLeft = 0;
+            }
+
+            if (itemsLeft == 0) return true;
+        }
+        return false;
     }
 
     @Override
     public void setInventorySlotContents(int slot, ItemStack stack) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return;
 
-        controller.setInventorySlotContents(slot, stack);
+        if (controller == null || controller.isInvalid()) return;
+
+        // Insertion
+        if (slot == 0) {
+
+            if (stack == null) return;
+
+            int itemsLeft = stack.stackSize;
+
+            for (int drawerSlot : controller.enumerateDrawersForInsertion(stack, false)) {
+
+                IDrawer drawer = controller.getDrawer(drawerSlot);
+
+                ItemStack itemProto = drawer.getStoredItemPrototype();
+                if (itemProto == null) {
+                    drawer = drawer.setStoredItemRedir(stack, 0);
+                }
+
+                itemsLeft = controller.insertItemsIntoDrawer(drawer, itemsLeft, false);
+
+                if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) itemsLeft = 0;
+                if (itemsLeft == 0) break;
+            }
+
+        }
+
+        // Extraction
+        else if (slot == 1 && IInventoryExtract != null) {
+
+            if (stack == null || (stack.isItemEqual(IInventoryExtract)
+                    && ItemStack.areItemStackTagsEqual(stack, IInventoryExtract))) {
+
+                // Get avaliable items in slot up to 64
+                int avaliableItems = 0;
+                for (int drawerSlot : controller.enumerateDrawersForExtraction(IInventoryExtract, true)) {
+                    IDrawer drawer = controller.getDrawer(drawerSlot);
+                    avaliableItems += drawer.getStoredItemCount();
+                    if (avaliableItems > this.getInventoryStackLimit()) {
+                        avaliableItems = this.getInventoryStackLimit();
+                        break;
+                    }
+                }
+
+                // Remove enough to make equal to stack.stackSize or 0 if stack is null
+                int toRemove = avaliableItems - ((stack == null) ? 0 : stack.stackSize);
+                for (int drawerSlot : controller.enumerateDrawersForExtraction(IInventoryExtract, true)) {
+
+                    IDrawer drawer = controller.getDrawer(drawerSlot);
+                    int itemCount = drawer.getStoredItemCount();
+
+                    if (toRemove > itemCount) {
+                        drawer.setStoredItemCount(0);
+                        toRemove -= itemCount;
+                    } else {
+                        drawer.setStoredItemCount(itemCount - toRemove);
+                        toRemove = 0;
+                    }
+                    if (toRemove == 0) break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public ItemStack decrStackSize(int slot, int count) {
+
+        if (slot == 0 || IInventoryExtract == null) return null;
+        if (controller == null || controller.isInvalid()) return null;
+
+        int amountRemoved = 0;
+        for (int drawerSlot : controller.enumerateDrawersForExtraction(IInventoryExtract, true)) {
+
+            IDrawer drawer = getDrawer(drawerSlot);
+            int itemCount = drawer.getStoredItemCount();
+
+            if (count > itemCount) {
+                drawer.setStoredItemCount(0);
+                amountRemoved += itemCount;
+                count -= itemCount;
+            } else {
+                drawer.setStoredItemCount(itemCount - count);
+                amountRemoved += (itemCount - count);
+                count = 0;
+            }
+
+            if (count == 0) return IInventoryExtract;
+        }
+
+        ItemStack itemsLeft = IInventoryExtract.copy();
+        itemsLeft.stackSize = amountRemoved;
+        return itemsLeft;
+    }
+
+    @Override
+    public ItemStack getStackInSlotOnClosing(int slot) {
+        if (controller == null || controller.isInvalid()) return null;
+        return controller.getStackInSlotOnClosing(slot);
     }
 
     @Override
     public String getInventoryName() {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return "storageDrawers.container.unboundSlave";
-
+        if (controller == null || controller.isInvalid()) return "storageDrawers.container.unboundSlave";
         return controller.getInventoryName();
     }
 
     @Override
     public boolean hasCustomInventoryName() {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return false;
-
+        if (controller == null || controller.isInvalid()) return false;
         return controller.hasCustomInventoryName();
     }
 
@@ -200,74 +330,118 @@ public class TileEntitySlave extends TileEntity implements IDrawerGroup, IPriori
     public void closeInventory() {}
 
     @Override
-    public boolean isItemValidForSlot(int slot, ItemStack stack) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return false;
+    public void controllerFullUpdate() {
+        if (controller == null || controller.isInvalid()) return;
+        controller.scheduleFullUpdate();
+    }
 
-        return controller.isItemValidForSlot(slot, stack);
+    @Override
+    public BlockCoord getControllerCoord() {
+        return controllerCoord;
+    }
+
+    @Override
+    public void setControllerCoord(int sourceControllerX, int sourceControllerY, int sourceControllerZ) {
+
+        if (controllerCoord == null || controllerCoord.x() != sourceControllerX
+                || controllerCoord.y() != sourceControllerY
+                || controllerCoord.z() != sourceControllerZ) {
+            controllerCoord = new BlockCoord(sourceControllerX, sourceControllerY, sourceControllerZ);
+            markDirty();
+        }
+
+        if (worldObj == null) return;
+
+        TileEntity te = worldObj.getTileEntity(controllerCoord.x(), controllerCoord.y(), controllerCoord.z());
+        if (te instanceof TileEntityController) {
+            controller = (TileEntityController) te;
+        }
+    }
+
+    @Override
+    public void clearControllerVariables(int sourceControllerX, int sourceControllerY, int sourceControllerZ,
+            boolean nullController) {
+
+        if (controllerCoord == null || controllerCoord.x() != sourceControllerX
+                || controllerCoord.y() != sourceControllerY
+                || controllerCoord.z() != sourceControllerZ) {
+
+        }
+        if (nullController) {
+            controllerCoord = null;
+            controller = null;
+            markDirty();
+        }
+    }
+
+    public TileEntityController getController() {
+        return controller;
+    }
+
+    @Override
+    public void updateEntity() {
+
+        if (isFirstTick && worldObj != null && !worldObj.isRemote && controllerCoord != null) {
+
+            isFirstTick = false;
+
+            TileEntity te = worldObj.getTileEntity(controllerCoord.x(), controllerCoord.y(), controllerCoord.z());
+
+            if (te instanceof TileEntityController) {
+                controller = ((TileEntityController) te);
+                ((TileEntityController) te).scheduleFullUpdate();
+            }
+        }
     }
 
     @Override
     public int getDrawerCount() {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return 0;
-
+        if (controller == null || controller.isInvalid()) return 0;
         return controller.getDrawerCount();
     }
 
     @Override
     public IDrawer getDrawer(int slot) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return null;
-
+        if (controller == null || controller.isInvalid()) return null;
         return controller.getDrawer(slot);
     }
 
     @Override
     public boolean isDrawerEnabled(int slot) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return false;
-
+        if (controller == null || controller.isInvalid()) return false;
         return controller.isDrawerEnabled(slot);
     }
 
     @Override
     public IDrawerInventory getDrawerInventory() {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return null;
-
+        if (controller == null || controller.isInvalid()) return null;
         return controller.getDrawerInventory();
     }
 
     @Override
     public Iterable<Integer> enumerateDrawersForInsertion(ItemStack stack, boolean strict) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return new ArrayList<Integer>();
-
+        if (controller == null || controller.isInvalid()) return new ArrayList<Integer>();
         return controller.enumerateDrawersForInsertion(stack, strict);
     }
 
     @Override
     public Iterable<Integer> enumerateDrawersForExtraction(ItemStack stack, boolean strict) {
-        TileEntityController controller = getController();
-        if (controller == null || !controller.isValidSlave(selfCoord)) return new ArrayList<Integer>();
-
+        if (controller == null || controller.isInvalid()) return new ArrayList<Integer>();
         return controller.enumerateDrawersForExtraction(stack, strict);
     }
 
     @Override
     public void markDirty() {
+
         TileEntityController controller = getController();
-        if (controller != null && controller.isValidSlave(selfCoord)) controller.markDirty();
+        if (controller != null && !controller.isInvalid()) controller.markDirty();
 
         super.markDirty();
     }
 
     @Override
     public boolean markDirtyIfNeeded() {
-        TileEntityController controller = getController();
-        if (controller != null && controller.isValidSlave(selfCoord)) return controller.markDirtyIfNeeded();
-
+        if (controller != null && !controller.isInvalid()) return controller.markDirtyIfNeeded();
         return false;
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/ae2/DrawerMEInventory.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/integration/ae2/DrawerMEInventory.java
@@ -32,6 +32,7 @@ public class DrawerMEInventory implements IMEInventory<IAEItemStack> {
 
     @Override
     public IAEItemStack injectItems(IAEItemStack input, Actionable type, BaseActionSource src) {
+
         long itemsLeft = input.getStackSize();
 
         if (group instanceof ISmartGroup) {
@@ -40,15 +41,16 @@ public class DrawerMEInventory implements IMEInventory<IAEItemStack> {
 
             try {
                 for (int slot : ((ISmartGroup) group).enumerateDrawersForInsertion(input.getItemStack(), false)) {
+
                     IDrawer drawer = group.getDrawer(slot);
                     ItemStack itemProto = drawer.getStoredItemPrototype();
+
                     if (itemProto == null) {
                         drawer = drawer.setStoredItemRedir(input.getItemStack(), 0);
                         if (clearSet != null) clearSet.add(drawer);
                     }
 
-                    if (drawer.canItemBeStored(input.getItemStack()))
-                        itemsLeft = injectItemsIntoDrawer(drawer, itemsLeft, type);
+                    itemsLeft = injectItemsIntoDrawer(drawer, itemsLeft, type);
 
                     if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) itemsLeft = 0;
                     if (itemsLeft == 0) return null;
@@ -58,6 +60,7 @@ public class DrawerMEInventory implements IMEInventory<IAEItemStack> {
                     for (IDrawer drawer : clearSet) drawer.setStoredItemRedir(null, 0);
                 }
             }
+
         } else {
             int[] order = null;
             if (group instanceof IPriorityGroup) order = ((IPriorityGroup) group).getAccessibleDrawerSlots();
@@ -133,13 +136,16 @@ public class DrawerMEInventory implements IMEInventory<IAEItemStack> {
 
     @Override
     public IAEItemStack extractItems(IAEItemStack request, Actionable mode, BaseActionSource src) {
+
         long itemsLeft = request.getStackSize();
         if (group instanceof ISmartGroup) {
+
             for (int slot : ((ISmartGroup) group).enumerateDrawersForExtraction(request.getItemStack(), true)) {
                 if (itemsLeft == 0) break;
 
                 IDrawer drawer = group.getDrawer(slot);
                 int itemCount = drawer.getStoredItemCount();
+
                 if (itemsLeft > itemCount) {
                     if (mode == Actionable.MODULATE) drawer.setStoredItemCount(0);
                     itemsLeft -= itemCount;
@@ -149,6 +155,7 @@ public class DrawerMEInventory implements IMEInventory<IAEItemStack> {
                     break;
                 }
             }
+
         } else {
             int[] order = null;
             if (group instanceof IPriorityGroup) order = ((IPriorityGroup) group).getAccessibleDrawerSlots();

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemCompDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemCompDrawers.java
@@ -34,7 +34,7 @@ public class ItemCompDrawers extends ItemDrawers {
             if (stack.hasTagCompound() && stack.getTagCompound().hasKey("tile"))
                 tile.readFromPortableNBT(stack.getTagCompound().getCompoundTag("tile"));
 
-            if (side > 1) tile.setDirection(side);
+            if (side > 1 && !player.isSneaking()) tile.setDirection(side);
 
             tile.setIsSealed(false);
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemController.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemController.java
@@ -26,7 +26,7 @@ public class ItemController extends ItemBlock {
         if (!super.placeBlockAt(stack, player, world, x, y, z, side, hitX, hitY, hitZ, metadata)) return false;
 
         TileEntityController tile = (TileEntityController) world.getTileEntity(x, y, z);
-        if (tile != null) {
+        if (tile != null && !player.isSneaking()) {
             if (side > 1) tile.setDirection(side);
         }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemDrawers.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/item/ItemDrawers.java
@@ -52,7 +52,7 @@ public class ItemDrawers extends ItemBlock {
             if (stack.hasTagCompound() && stack.getTagCompound().hasKey("tile"))
                 tile.readFromPortableNBT(stack.getTagCompound().getCompoundTag("tile"));
 
-            if (side > 1) tile.setDirection(side);
+            if (side > 1 && !player.isSneaking()) tile.setDirection(side);
 
             tile.setIsSealed(false);
         }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/BaseDrawerData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/BaseDrawerData.java
@@ -15,6 +15,7 @@ import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.inventory.IInventoryAdapter;
 import com.jaquadro.minecraft.storagedrawers.api.inventory.SlotType;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 import com.jaquadro.minecraft.storagedrawers.inventory.InventoryStack;
 
 import cpw.mods.fml.relauncher.Side;
@@ -23,12 +24,43 @@ import cpw.mods.fml.relauncher.SideOnly;
 public abstract class BaseDrawerData implements IDrawer, IInventoryAdapter {
 
     protected InventoryStack inventoryStack;
-    private List<ItemStack> oreDictMatches;
+    protected List<ItemStack> oreDictMatches;
     private Map<String, Object> auxData;
     @SideOnly(Side.CLIENT)
     private ItemStack itemStackForRender;
     @SideOnly(Side.CLIENT)
     private EntityItem entityItemForRender;
+
+    /**
+     * This is the index of the SlotRecord inside controller variable drawerSlotList when a controller is connected
+     * (Used to update controller lookup when item in the slot is changed)
+     */
+    protected int controllerDrawerSlot = -1;
+    protected TileEntityController controller = null;
+
+    public List<ItemStack> getOreDictMatches() {
+        return oreDictMatches;
+    }
+
+    public TileEntityController getController() {
+        return controller;
+    }
+
+    public int getControllerDrawerSlot() {
+        return controllerDrawerSlot;
+    }
+
+    public void setTileEntityController(TileEntityController controller, int controllerDrawerSlot) {
+
+        this.controller = controller;
+        this.controllerDrawerSlot = controllerDrawerSlot;
+    }
+
+    public void clearTileEntityController() {
+
+        this.controller = null;
+        this.controllerDrawerSlot = -1;
+    }
 
     protected BaseDrawerData() {
         inventoryStack = new DrawerInventoryStack();
@@ -70,7 +102,7 @@ public abstract class BaseDrawerData implements IDrawer, IInventoryAdapter {
                 }
             }
 
-            if (oreDictMatches.size() == 0) oreDictMatches = null;
+            if (oreDictMatches.isEmpty()) oreDictMatches = null;
         }
     }
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/CompDrawerData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/CompDrawerData.java
@@ -33,16 +33,11 @@ public class CompDrawerData extends BaseDrawerData
     @Override
     public void setStoredItem(ItemStack itemPrototype, int amount) {
         central.setStoredItem(slot, itemPrototype, amount);
-        refresh();
-
-        // markDirty
     }
 
     @Override
     public IDrawer setStoredItemRedir(ItemStack itemPrototype, int amount) {
         IDrawer target = central.setStoredItem(slot, itemPrototype, amount);
-        refresh();
-
         return target;
     }
 
@@ -53,7 +48,7 @@ public class CompDrawerData extends BaseDrawerData
 
     @Override
     public void setStoredItemCount(int amount) {
-        central.setStoredItemCount(slot, amount);
+        central.setStoredItemCount(slot, amount, controller, controllerDrawerSlot);
     }
 
     @Override

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DefaultStorageProvider.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DefaultStorageProvider.java
@@ -5,6 +5,7 @@ import net.minecraft.tileentity.TileEntity;
 import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 import com.jaquadro.minecraft.storagedrawers.network.CountUpdateMessage;
 
 import cpw.mods.fml.common.network.NetworkRegistry;
@@ -15,6 +16,9 @@ public class DefaultStorageProvider implements IStorageProvider {
     TileEntity tile;
     IDrawerGroup group;
 
+    /**
+     * If the DrawerData that this is in has a drawer controller, markDirty/markAmountDirty schedules client sync
+     */
     public DefaultStorageProvider(TileEntity tileEntity, IDrawerGroup drawerGroup) {
         tile = tileEntity;
         group = drawerGroup;
@@ -89,34 +93,44 @@ public class DefaultStorageProvider implements IStorageProvider {
     }
 
     @Override
-    public void markAmountDirty(int slot) {
+    public void markAmountDirty(int slot, TileEntityController controller) {
         if (tile.getWorldObj().isRemote) return;
 
-        int count = group.getDrawer(slot).getStoredItemCount();
+        if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+            controller.addClientSyncList(tile.xCoord, tile.yCoord, tile.zCoord);
+        } else {
 
-        IMessage message = new CountUpdateMessage(tile.xCoord, tile.yCoord, tile.zCoord, slot, count);
-        NetworkRegistry.TargetPoint targetPoint = new NetworkRegistry.TargetPoint(
-                tile.getWorldObj().provider.dimensionId,
-                tile.xCoord,
-                tile.yCoord,
-                tile.zCoord,
-                500);
+            tile.getWorldObj().markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);
 
-        StorageDrawers.network.sendToAllAround(message, targetPoint);
+            int count = group.getDrawer(slot).getStoredItemCount();
+            IMessage message = new CountUpdateMessage(tile.xCoord, tile.yCoord, tile.zCoord, slot, count);
+            NetworkRegistry.TargetPoint targetPoint = new NetworkRegistry.TargetPoint(
+                    tile.getWorldObj().provider.dimensionId,
+                    tile.xCoord,
+                    tile.yCoord,
+                    tile.zCoord,
+                    500);
+            StorageDrawers.network.sendToAllAround(message, targetPoint);
+        }
 
-        tile.getWorldObj().markTileEntityChunkModified(tile.xCoord, tile.yCoord, tile.zCoord, tile);
         if (isRedstone(slot)) {
             tile.getWorldObj().notifyBlocksOfNeighborChange(tile.xCoord, tile.yCoord, tile.zCoord, tile.getBlockType());
             tile.getWorldObj()
                     .notifyBlocksOfNeighborChange(tile.xCoord, tile.yCoord - 1, tile.zCoord, tile.getBlockType());
+
         }
+        tile.getWorldObj().markTileEntityChunkModified(tile.xCoord, tile.yCoord, tile.zCoord, tile);
     }
 
     @Override
-    public void markDirty(int slot) {
+    public void markDirty(TileEntityController controller) {
         if (tile.getWorldObj().isRemote) return;
 
-        tile.getWorldObj().markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);
+        if (controller != null && !controller.isInvalid() && !controller.getClientAutoSync()) {
+            controller.addClientSyncList(tile.xCoord, tile.yCoord, tile.zCoord);
+        } else {
+            tile.getWorldObj().markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);
+        }
         tile.getWorldObj().markTileEntityChunkModified(tile.xCoord, tile.yCoord, tile.zCoord, tile);
     }
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DrawerData.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/DrawerData.java
@@ -5,6 +5,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 
+import com.jaquadro.minecraft.storagedrawers.StorageDrawers;
 import com.jaquadro.minecraft.storagedrawers.api.event.DrawerPopulatedEvent;
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.ILockable;
@@ -18,18 +19,50 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
 
     private static final ItemStack nullStack = new ItemStack((Item) null);
 
-    private IStorageProvider storageProvider;
-    private int slot;
+    // Syncs Client with Server and marks chunk for saving when protostack/count changes
+    private final IStorageProvider storageProvider;
 
+    // Drawer Slot within IDrawerGroup
+    private final int slot;
+
+    // Item that is held in this slot
     private ItemStack protoStack;
     private int count;
 
     public DrawerData(IStorageProvider provider, int slot) {
+
         storageProvider = provider;
         protoStack = nullStack;
         this.slot = slot;
 
         postInit();
+    }
+
+    public void setLookupController(ItemStack itemPrototype) {
+
+        if (controller == null || controller.isInvalid() || controllerDrawerSlot == -1) {
+            clearTileEntityController();
+        } else if (itemPrototype != nullStack) {
+            controller.setLookup(
+                    itemPrototype,
+                    controllerDrawerSlot,
+                    StorageDrawers.config.cache.enableItemConversion ? oreDictMatches : null);
+        }
+
+    }
+
+    public void removeLookupController() {
+
+        if (controller == null || controller.isInvalid() || controllerDrawerSlot == -1) {
+            clearTileEntityController();
+        }
+
+        else if (protoStack != nullStack) {
+            controller.removeLookup(
+                    protoStack,
+                    controllerDrawerSlot,
+                    StorageDrawers.config.cache.enableItemConversion ? oreDictMatches : null);
+        }
     }
 
     @Override
@@ -56,29 +89,38 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
     }
 
     private void setStoredItem(ItemStack itemPrototype, int amount, boolean mark) {
+
         if (itemPrototype == null) {
-            setStoredItemCount(0, false, true);
+
+            removeLookupController();
+
+            boolean amountDirty = protoStack == null;
+
             protoStack = nullStack;
             inventoryStack.reset();
+
+            setStoredItemCount(0, false, true, amountDirty);
 
             DrawerPopulatedEvent event = new DrawerPopulatedEvent(this);
             MinecraftForge.EVENT_BUS.post(event);
 
-            if (mark) storageProvider.markDirty(slot);
             return;
         }
 
+        boolean amountDirty = (protoStack == null || !itemPrototype.isItemEqual(protoStack)
+                || !ItemStack.areItemStackTagsEqual(itemPrototype, protoStack));
+
         protoStack = itemPrototype.copy();
         protoStack.stackSize = 1;
-
-        refreshOreDictMatches();
-        setStoredItemCount(amount, mark, false);
         inventoryStack.reset();
+        refreshOreDictMatches();
+
+        setLookupController(protoStack);
+
+        setStoredItemCount(amount, mark, false, amountDirty);
 
         DrawerPopulatedEvent event = new DrawerPopulatedEvent(this);
         MinecraftForge.EVENT_BUS.post(event);
-
-        if (mark) storageProvider.markDirty(slot);
     }
 
     @Override
@@ -90,21 +132,28 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
 
     @Override
     public void setStoredItemCount(int amount) {
-        setStoredItemCount(amount, true, true);
+        setStoredItemCount(amount, true, true, amount != 0);
     }
 
-    public void setStoredItemCount(int amount, boolean mark, boolean clearOnEmpty) {
+    public void setStoredItemCount(int amount, boolean mark, boolean clearOnEmpty, boolean amountDirty) {
+
         if (isVendingUnlimited()) return;
 
         count = amount;
         if (count > getMaxCapacity()) count = getMaxCapacity();
 
-        if (amount == 0) {
-            if (clearOnEmpty) {
-                if (!storageProvider.isLocked(slot, LockAttribute.LOCK_POPULATED)) reset();
-                if (mark) storageProvider.markDirty(slot);
+        if (amount == 0 && clearOnEmpty) {
+            if (!storageProvider.isLocked(slot, LockAttribute.LOCK_POPULATED)) {
+                reset();
             }
-        } else if (mark) storageProvider.markAmountDirty(slot);
+        }
+        if (mark) {
+            if (amountDirty) {
+                storageProvider.markAmountDirty(slot, controller);
+            } else {
+                storageProvider.markDirty(controller);
+            }
+        }
     }
 
     @Override
@@ -180,6 +229,8 @@ public class DrawerData extends BaseDrawerData implements IVoidable, IShroudable
 
     @Override
     protected void reset() {
+
+        removeLookupController();
         protoStack = nullStack;
         super.reset();
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/ICentralInventory.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/ICentralInventory.java
@@ -5,6 +5,7 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 
 public interface ICentralInventory {
 
@@ -14,7 +15,7 @@ public interface ICentralInventory {
 
     public int getStoredItemCount(int slot);
 
-    public void setStoredItemCount(int slot, int amount);
+    public void setStoredItemCount(int slot, int amount, TileEntityController controller, int controllerDrawerSlot);
 
     public int getMaxCapacity(int slot);
 

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/IStorageProvider.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/storage/IStorageProvider.java
@@ -1,6 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.storage;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.LockAttribute;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
 
 public interface IStorageProvider {
 
@@ -32,7 +33,7 @@ public interface IStorageProvider {
 
     public boolean isRedstone(int slot);
 
-    public void markAmountDirty(int slot);
+    public void markAmountDirty(int slot, TileEntityController controller);
 
-    public void markDirty(int slot);
+    public void markDirty(TileEntityController controller);
 }

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/ItemHashMap.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/ItemHashMap.java
@@ -1,0 +1,185 @@
+package com.jaquadro.minecraft.storagedrawers.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class ItemHashMap {
+
+    // Takes a key (based on item) and returns list of drawers with this item
+    private final Map<Integer, List<SlotRecord>> registry;
+
+    // Takes same type of key as registry and maps to a set registry keys
+    private final Map<Integer, Set<Integer>> oreDictRegistryMatch;
+
+    public ItemHashMap() {
+        registry = new HashMap<>();
+        oreDictRegistryMatch = new HashMap<>();
+    }
+
+    public void clear() {
+        for (List<SlotRecord> list : registry.values()) {
+            list.clear();
+        }
+        registry.clear();
+        for (Set<Integer> list : oreDictRegistryMatch.values()) {
+            list.clear();
+        }
+        oreDictRegistryMatch.clear();
+    }
+
+    /**
+     * Register an ItemStack -> slotRecord for lookup. oreDictItems allows access to this entry if the requested item is
+     * present in this list when oreDict is enabled.
+     *
+     */
+    public void register(Item item, int meta, SlotRecord entry, List<ItemStack> oreDictItems) {
+
+        // Convert ItemStack into an integer key to use for the map
+        int key = (Item.getIdFromItem(item) << 16) | meta;
+
+        List<SlotRecord> registryList = registry.get(key);
+
+        if (registryList == null) {
+            registryList = new ArrayList<>();
+            registry.put(key, registryList);
+        }
+        registryList.add(entry);
+
+        if (oreDictItems != null) {
+
+            for (ItemStack oreItem : oreDictItems) {
+
+                // Convert ItemStack into an integer key for lookup
+                int oreDictKey = (Item.getIdFromItem(oreItem.getItem()) << 16) | oreItem.getItemDamage();
+
+                // Prevent key in registry from also appearing in the oreDictRegistryMatch
+                if (oreDictKey == key) continue;
+
+                // Update oreDictList
+                Set<Integer> oreDictList = oreDictRegistryMatch.get(oreDictKey);
+                if (oreDictList == null) {
+                    oreDictList = new HashSet<>();
+                    oreDictRegistryMatch.put(oreDictKey, oreDictList);
+                }
+                oreDictList.add(key);
+            }
+        }
+    }
+
+    /**
+     * Remove ItemStack -> SlotRecord entry and associated oreDict matches if they are not being used. oreDictItems
+     * should always be the same as the one used for registering the item.
+     **/
+    public void remove(Item item, int meta, SlotRecord entry, List<ItemStack> oreDictItems) {
+
+        int key = (Item.getIdFromItem(item) << 16) | meta;
+
+        List<SlotRecord> registryList = registry.get(key);
+
+        if (registryList == null || !registryList.remove(entry) || !registryList.isEmpty()) return;
+
+        registry.remove(key);
+
+        if (oreDictItems != null) {
+
+            for (ItemStack stack : oreDictItems) {
+
+                int oreDictKey = (Item.getIdFromItem(stack.getItem()) << 16) | stack.getItemDamage();
+
+                Set<Integer> oreDictList = oreDictRegistryMatch.get(oreDictKey);
+
+                if (oreDictList == null) continue;
+
+                oreDictList.remove(key);
+
+                if (oreDictList.isEmpty()) oreDictRegistryMatch.remove(oreDictKey);
+            }
+        }
+    }
+
+    /**
+     * Iterates though SlotRecords for a given ItemStack starting with exact registry matches before fetching records
+     * with oreDict matches if present. next() returns nextRecord variable gets updated in advance().
+     **/
+    public Iterator<SlotRecord> candidateIterator(Item item, int meta) {
+        return new ItemHashMapIterator(item, meta);
+    }
+
+    private class ItemHashMapIterator implements Iterator<SlotRecord> {
+
+        private Iterator<SlotRecord> primaryMatches;
+        private Iterator<Integer> oreDictIterator;
+
+        private Iterator<SlotRecord> oreDictMatches = null;
+        private SlotRecord nextRecord = null;
+
+        public ItemHashMapIterator(Item item, int meta) {
+
+            Integer itemKey = (Item.getIdFromItem(item) << 16) | meta;
+
+            List<SlotRecord> primary = registry.get(itemKey);
+            primaryMatches = (primary != null) ? primary.iterator() : null;
+
+            Set<Integer> oreKeys = oreDictRegistryMatch.get(itemKey);
+            oreDictIterator = (oreKeys != null) ? oreKeys.iterator() : null;
+        }
+
+        private void advance() {
+
+            // Direct matches first
+            if (primaryMatches != null && primaryMatches.hasNext()) {
+
+                nextRecord = primaryMatches.next();
+                return;
+            }
+
+            // Find next key in the oreDictIterator of Set<Integer> if needed
+            while ((oreDictMatches == null || !oreDictMatches.hasNext()) && oreDictIterator != null
+                    && oreDictIterator.hasNext()) {
+
+                Integer key = oreDictIterator.next();
+
+                List<SlotRecord> matches = registry.get(key);
+
+                if (matches != null && !matches.isEmpty()) {
+
+                    oreDictMatches = matches.iterator();
+                }
+            }
+
+            // Oredict matches second
+            if (oreDictMatches != null && oreDictMatches.hasNext()) {
+
+                nextRecord = oreDictMatches.next();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+
+            if (nextRecord == null) advance();
+
+            return nextRecord != null;
+        }
+
+        @Override
+        public SlotRecord next() {
+
+            if (!hasNext()) throw new NoSuchElementException();
+
+            SlotRecord slot = nextRecord;
+            nextRecord = null;
+
+            return slot;
+        }
+    }
+}

--- a/src/main/java/com/jaquadro/minecraft/storagedrawers/util/SlotRecord.java
+++ b/src/main/java/com/jaquadro/minecraft/storagedrawers/util/SlotRecord.java
@@ -1,0 +1,24 @@
+package com.jaquadro.minecraft.storagedrawers.util;
+
+import com.jaquadro.minecraft.storagedrawers.block.tile.BlockCoord;
+
+public class SlotRecord {
+
+    public final BlockCoord coord;
+
+    /** Slot inside Drawer */
+    public final int slot;
+
+    /** Index inside controller drawerSlotList variable */
+    public int listIndex;
+
+    /** Index inside controller drawerSlots variable */
+    public int priorityIndex;
+
+    public SlotRecord(BlockCoord coord, int slot, int listIndex) {
+        this.coord = coord;
+        this.slot = slot;
+        this.listIndex = listIndex;
+        this.priorityIndex = -1;
+    }
+}


### PR DESCRIPTION
Changed a few things to help improve performance especially when changing the config to allow more drawers than 50 in GTNH. This was tested with 200 * 4 drawers full of items:

In this version each drawer is bound to a single controller and when a new controller is added it causes the drawers to clear the old controller. Previously you could have multiple controllers connected to the same drawer. This is done so that each time the item in a drawer changes it lets the controller know rather than the controller performing periodic full updates.

In these changes controller only schedules full update once when loading or adding/removing drawers (on testing takes around 700us when using 200 * 4 drawers on my PC) previously this was done every controller tick. It will schedule priority update only when a slot is emptied/new item inserted or upgrade is applied to drawer which is less work (around 200us previously was done every drawer tick as well) 

Item lookup (ItemHashMap) has been added to replace ItemMetaListRegistry it now updates when inserting new item instead of when the controller updates preventing the need to search every drawer when no match is found. Also includes oredict lookup a direct match is not found.

For inserting new items, index of empty drawer is calculated when drawer is emptied or when running priority update making inserting new items or attempting to insert an item while storage is full much faster.

**The following operations should be much faster:**
Inserting new item
Oredict match insertion
Extracting recently inserted new item (before controller updates) 
Attempting to insert an item without space
Attempting to extract an item that doesn't exist/drawer empty

Before these took around 200us to 300us on my PC (for 200 *4 slots) new one is around 10-20us regardless of size. 
This was tested with ME storage bus which calls extractItems inside DrawerMEinventory using enumerateDrawersForExtraction method in the tileEntityController class.

IIinventory functions now use same enumerateDrawersForInsertion/enumerateDrawersForExtraction function that ME/Logistics pipes use  removing the need for separate inventory variables and should make performance with IIinventory much faster. **Controller has 2 virtual slots one for inserting and 1 for extracting. With this only 1 item type can be extracted per controller/slave and is set by clicking the side with an item (shift clicking with empty item resets it).** Have tested with hopper and GT pipes. (GT pipes appear to use setInventorySlotContents to extract rather than decrStackSize that hoppers use)

**Controller front can be shift clicked to disable real time client syncing** when inserting items to controller connected drawers, causing item displayed and quantity shown not to update straight away until drawer or controller is interacted with (or reloading game) as these are very slow.

Some bugs were fixed such as status upgrade 1 not updating when extracting items after being full and interactPutItemsIntoSlot inside onBlockActivated in the blockDrawers class running on the client. Also made it so you can shift click while placing a drawer on another drawers side face you rather than face left or right (small change in itemDrawers, itemController, itemCompDrawers).

Some things will probably need to be changed like the text being localized but just wanted to get this out.